### PR TITLE
support clinical summary updates that arrive by push from Redox

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.vital-software"
 
 name := "scala-redox"
 
-version := "0.2-SNAPSHOT"
+version := "0.3-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -168,13 +168,14 @@ object RedoxClient {
     import com.github.vitalsoftware.scalaredox.models.RedoxEventTypes._
     val reads = (__ \ "Meta").read[models.Meta]
     val unsupported = JsError("Not yet supported").errors
+    val clinicalSummaryTypes = List(PatientQueryResponse, PatientPush)
+    val visitTypes = List(VisitQueryResponse, VisitPush)
+
     json.validate[models.Meta](reads).fold(
       invalid = errors => Left(errors),
       valid = { meta =>
         meta.DataModel match {
           case Claim =>               Left(unsupported)
-          case ClinicalSummary if meta.EventType == PatientQueryResponse => json.validate[models.ClinicalSummary].asEither
-          case ClinicalSummary if meta.EventType == VisitQueryResponse   => json.validate[models.Visit].asEither
           case Device =>              Left(unsupported)
           case Financial =>           Left(unsupported)
           case Flowsheet =>           Left(unsupported)
@@ -189,6 +190,8 @@ object RedoxClient {
           case Scheduling =>          Left(unsupported)
           case SurgicalScheduling =>  Left(unsupported)
           case Vaccination =>         Left(unsupported)
+          case _ if clinicalSummaryTypes.contains(meta.EventType) => json.validate[models.ClinicalSummary].asEither
+          case _ if visitTypes.contains(meta.EventType) => json.validate[models.Visit].asEither
           case _ =>                   Left(unsupported)
         }
       }

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/ClinicalSummary.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/ClinicalSummary.scala
@@ -102,7 +102,7 @@ import com.github.vitalsoftware.macros._
 ) extends ClinicalSummaryLike
 
 // Common structure between Visit and ClinicalSummary
-trait ClinicalSummaryLike {
+trait ClinicalSummaryLike extends MetaLike {
   def Allergies: Seq[Allergy]
   def Encounters: Seq[Encounter]
   def Medications: Seq[MedicationTaken]

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
@@ -49,4 +49,4 @@ object MediaAvailability extends Enumeration {
   Patient: Patient,
   Media: Media,
   Visit: Option[VisitInfo] = None
-)
+) extends MetaLike

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/MetaLike.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/MetaLike.scala
@@ -1,0 +1,5 @@
+package com.github.vitalsoftware.scalaredox.models
+
+trait MetaLike {
+  def Meta: Meta
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -63,4 +63,4 @@ object NoteContentTypes extends Enumeration {
                                       Visit: Option[VisitInfo] = None,
                                       Note: Note,
                                       Orders: Seq[NoteOrder] = Seq.empty
-)
+) extends MetaLike

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -173,4 +173,4 @@ object ResultsStatusTypes extends Enumeration {
                                        Patient: Patient,
                                        Visit: Option[VisitInfo] = None,
                                        Order: Order
-)
+) extends MetaLike

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -94,4 +94,4 @@ object Gender extends Enumeration {
   Meta: Meta,
   Patient: Option[Patient] = None,
   PotentialMatches: Seq[Patient] = Seq.empty
-)
+) extends MetaLike

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -30,4 +30,4 @@ import com.github.vitalsoftware.macros._
   Patient: Patient,
   Orders: Seq[Order] = Seq.empty,
   Visit: Option[VisitInfo] = None
-)
+) extends MetaLike


### PR DESCRIPTION
When Clinical Summary is pushed by Redox, it has event types of either PatientPush or VisitPush. These types has not been supported

Part of https://github.com/vital-software/api/issues/207