### PR TITLE
Fix collision of dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.vital-software"
 
 name := "scala-redox"
 
-version := "0.3"
+version := "0.4-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
@@ -13,8 +13,8 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.6.0-M3",
-  "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0-M4",
+  "com.typesafe.play" %% "play-json" % "2.6.0-M6",
+  "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0-RC1",
   "com.typesafe.akka" %% "akka-http" % "10.0.1",
   //"ai.x" %% "play-json-extensions" % "0.8.0",
   "com.iheart" %% "ficus" % "1.4.0",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.0-M6",
-  "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0-RC1",
+  "com.typesafe.play" %% "play-ws" % "2.5.12",
   "com.typesafe.akka" %% "akka-http" % "10.0.1",
   //"ai.x" %% "play-json-extensions" % "0.8.0",
   "com.iheart" %% "ficus" % "1.4.0",

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -26,11 +26,12 @@ class RedoxClient(conf: Config) {
   implicit val system = ActorSystem()
   implicit val materializer = ActorMaterializer()
 
-  protected lazy val client = StandaloneAhcWSClient()
+  private val clientConfig = AhcWSClientConfigFactory.forConfig(conf)
+  protected val client = StandaloneAhcWSClient(clientConfig)
 
-  private[client] lazy val apiKey = conf.as[String]("redox.apiKey")
-  private[client] lazy val apiSecret = conf.as[String]("redox.secret")
-  private[client] lazy val baseRestUri = Uri(conf.getOrElse[String]("redox.restApiBase", "https://api.redoxengine.com"))
+  private[client] val apiKey = conf.as[String]("redox.apiKey")
+  private[client] val apiSecret = conf.as[String]("redox.secret")
+  private[client] val baseRestUri = Uri(conf.getOrElse[String]("redox.restApiBase", "https://api.redoxengine.com"))
   private[client] lazy val authInfo = {
     val auth = new SyncVar[Option[AuthInfo]]
     auth.put(None)
@@ -48,7 +49,7 @@ class RedoxClient(conf: Config) {
         case Some(info) => Future { info }
         case None => authorize()
       }
-      response <- execute[T](request.withHeaders("Authorization" -> s"Bearer ${auth.accessToken}"))
+      response <- execute[T](request.withHttpHeaders("Authorization" -> s"Bearer ${auth.accessToken}"))
     } yield response
   }
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -67,7 +67,7 @@ class RedoxClient(conf: Config) {
       ).contains(r.status) =>
         Try {
           // In case we do not get valid JSON back, wrap everything in a Try block
-          r.json.as[RedoxErrorResponse]
+          (r.json \ "Meta").as[RedoxErrorResponse]
         } match {
           case Success(t) => Left(t)
           case Failure(e) => Left(RedoxErrorResponse.simple(r.statusText))

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -1,6 +1,6 @@
 package com.github.vitalsoftware.scalaredox.models
 
-import org.joda.time.LocalDate
+import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaDateFormat
 import com.github.vitalsoftware.macros._
 import play.api.libs.json.Reads.DefaultJodaDateReads
@@ -43,7 +43,7 @@ object Gender extends Enumeration {
 @jsonDefaults case class Demographics(
   FirstName: String,
   LastName: String,
-  DOB: LocalDate,
+  DOB: DateTime,
   SSN: Option[String] = None,
   Sex: Gender.Value,
   Address: Option[Address] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -1,6 +1,6 @@
 package com.github.vitalsoftware.scalaredox.models
 
-import org.joda.time.DateTime
+import org.joda.time.LocalDate
 import com.github.vitalsoftware.util.JsonImplicits.jodaDateFormat
 import com.github.vitalsoftware.macros._
 import play.api.libs.json.Reads.DefaultJodaDateReads
@@ -43,7 +43,7 @@ object Gender extends Enumeration {
 @jsonDefaults case class Demographics(
   FirstName: String,
   LastName: String,
-  DOB: DateTime,
+  DOB: LocalDate,
   SSN: Option[String] = None,
   Sex: Gender.Value,
   Address: Option[Address] = None,

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -2,7 +2,7 @@ package com.github.vitalsoftware.scalaredox
 
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models._
-import org.joda.time.LocalDate
+import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
@@ -19,7 +19,7 @@ class ClinicalSummaryTest extends Specification with NoTimeConversions with Redo
     "return an error" in {
       val shouldFailQuery = PatientQuery(
         Meta(DataModel = DataModelTypes.ClinicalSummary, EventType = RedoxEventTypes.Query),
-        Patient(Demographics = Some(Demographics("John", "Doe", LocalDate.parse("1970-1-1"), Sex = Gender.Male)))
+        Patient(Demographics = Some(Demographics("John", "Doe", DateTime.parse("1970-1-1"), Sex = Gender.Male)))
       )
       val fut = client.get[PatientQuery, ClinicalSummary](shouldFailQuery)
       val resp = Await.result(fut, 5.seconds)

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -34,7 +34,7 @@ class ClinicalSummaryTest extends Specification with NoTimeConversions with Redo
           |{
           |	"Meta": {
           |		"DataModel": "Clinical Summary",
-          |		"EventType": "Query",
+          |		"EventType": "PatientQuery",
           |		"EventDateTime": "2017-03-14T19:35:06.047Z",
           |		"Test": true,
           |		"Destinations": [
@@ -71,7 +71,7 @@ class ClinicalSummaryTest extends Specification with NoTimeConversions with Redo
 
         // Meta
         val meta = clinicalSummary.Meta
-        meta.EventType must be equalTo RedoxEventTypes.Query
+        meta.EventType must be equalTo RedoxEventTypes.PatientQuery
         meta.Destinations must not be empty
 
         // Vital Signs

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -2,7 +2,7 @@ package com.github.vitalsoftware.scalaredox
 
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models._
-import org.joda.time.DateTime
+import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
@@ -19,7 +19,7 @@ class ClinicalSummaryTest extends Specification with NoTimeConversions with Redo
     "return an error" in {
       val shouldFailQuery = PatientQuery(
         Meta(DataModel = DataModelTypes.ClinicalSummary, EventType = RedoxEventTypes.Query),
-        Patient(Demographics = Some(Demographics("John", "Doe", DateTime.parse("1970-1-1"), Sex = Gender.Male)))
+        Patient(Demographics = Some(Demographics("John", "Doe", LocalDate.parse("1970-1-1"), Sex = Gender.Male)))
       )
       val fut = client.get[PatientQuery, ClinicalSummary](shouldFailQuery)
       val resp = Await.result(fut, 5.seconds)


### PR DESCRIPTION
Colliding dependencies:
- scala-redox depends on "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0-RC1"
- api depends on "com.typesafe.play" %% "play-ws" % "2.5.2"

Unfortunately, play-ws jar does not depend on play-ws-standalone, but has the class inside itself. So it is not possible to exclude transitive dependency from the sbt. Instead, I replaced play-ahc-ws-standalone with play-ws in scala-redox project. It fixes the problem now, but it will be hard to keep dependencies in sync in both projects.