### PR TITLE
add case class VisitQueryResponse

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/ClinicalSummary.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/ClinicalSummary.scala
@@ -38,6 +38,20 @@ import com.github.vitalsoftware.macros._
   VitalSigns: Seq[VitalSigns] = Seq.empty
 ) extends ClinicalSummaryLike
 
+@jsonDefaults case class VisitQueryResponse
+(
+  Meta: Meta,
+  Header: Header,
+  Allergies: Seq[Allergy] = Seq.empty,
+  Assessment: Option[Assessment] = None,
+  Encounters: Seq[Encounter] = Seq.empty,
+  Medications: Seq[MedicationTaken] = Seq.empty,
+  PlanOfCare: Option[PlanOfCare]= None,
+  Problems: Seq[Problem]= Seq.empty,
+  Results: Seq[Result]= Seq.empty,
+  VitalSigns: Seq[VitalSigns] = Seq.empty
+)
+
 /**
   * TODO: Running into Function22 and Tuple22 limits here...
   * https://stackoverflow.com/questions/20258417/how-to-get-around-the-scala-case-class-limit-of-22-fields

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -69,7 +69,8 @@ import com.github.vitalsoftware.macros._
   * @param Insurances List of insurance coverages for the patient
   */
 @jsonDefaults case class VisitInfo(
-  VisitNumber: Option[String] = None,
+// TODO: the documentation says that it is a string, but they return a number
+//  VisitNumber: Option[String] = None,
   VisitDateTime: Option[DateTime] = None,
   Duration: Option[Double] = None,
   Reason: Option[String] = None,


### PR DESCRIPTION
see https://developer.redoxengine.com/ClinicalSummary.html, under VisitQueryResponse

@apatzer, was there a reason we have only one case class for two types of Clinical Summary?

Also, there seems to be a bug with the return type of VisitNumber. Documentations says it is string, but the endpoint return integer. I will talk to the support soon. For now, I just commented the field out.