### PR TITLE
Fix/restore visit number

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.github.vital-software"
 
 name := "scala-redox"
 
-version := "0.83-SNAPSHOT"
+version := "0.84-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -68,8 +68,7 @@ import com.github.vitalsoftware.macros._
  * @param Insurances List of insurance coverages for the patient
  */
 @jsonDefaults case class VisitInfo(
-  // TODO: the documentation says that it is a string, but they return a number
-  //  VisitNumber: Option[String] = None,
+  VisitNumber: Option[String] = None,
   VisitDateTime: Option[DateTime] = None,
   Duration: Option[Double] = None,
   Reason: Option[String] = None,

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -10,8 +10,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
-  * Created by apatzer on 3/23/17.
-  */
+ * Created by apatzer on 3/23/17.
+ */
 class ClinicalSummaryTest extends Specification with NoTimeConversions with RedoxTest {
 
   "query ClinicalSummary" should {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
@@ -5,9 +5,9 @@ import com.github.vitalsoftware.scalaredox.models._
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
-import play.api.libs.json.{JsError, Json}
+import play.api.libs.json.{ JsError, Json }
 
-import concurrent.{Await, Future}
+import concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 class ConnectionTest extends Specification with NoTimeConversions with RedoxTest {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/MediaTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/MediaTest.scala
@@ -6,8 +6,8 @@ import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
 /**
-  * Created by apatzer on 3/23/17.
-  */
+ * Created by apatzer on 3/23/17.
+ */
 class MediaTest extends Specification with NoTimeConversions with RedoxTest {
 
   "alter Media" should {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/NotesTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/NotesTest.scala
@@ -6,8 +6,8 @@ import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
 /**
-  * Created by apatzer on 3/23/17.
-  */
+ * Created by apatzer on 3/23/17.
+ */
 class NotesTest extends Specification with NoTimeConversions with RedoxTest {
 
   "alter Notes" should {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/OrderTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/OrderTest.scala
@@ -6,8 +6,8 @@ import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
 /**
-  * Created by apatzer on 3/23/17.
-  */
+ * Created by apatzer on 3/23/17.
+ */
 class OrderTest extends Specification with NoTimeConversions with RedoxTest {
 
   "alter Orders" should {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/PatientSearchTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/PatientSearchTest.scala
@@ -8,8 +8,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
-  * Created by apatzer on 3/23/17.
-  */
+ * Created by apatzer on 3/23/17.
+ */
 class PatientSearchTest extends Specification with NoTimeConversions with RedoxTest {
 
   "query PatientSearch" should {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
@@ -2,16 +2,16 @@ package com.github.vitalsoftware.scalaredox
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.github.vitalsoftware.scalaredox.client.{RedoxClient, RedoxResponse}
+import com.github.vitalsoftware.scalaredox.client.{ RedoxClient, RedoxResponse }
 import com.typesafe.config.ConfigFactory
-import play.api.libs.json.{JsError, Json, Reads}
+import play.api.libs.json.{ JsError, Json, Reads }
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 /**
-  * Created by apatzer on 3/23/17.
-  */
+ * Created by apatzer on 3/23/17.
+ */
 trait RedoxTest {
 
   val conf = ConfigFactory.load("resources/reference.conf")

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ResultsTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ResultsTest.scala
@@ -1,13 +1,13 @@
 package com.github.vitalsoftware.scalaredox
 
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
-import com.github.vitalsoftware.scalaredox.models.{Result, ResultsMessage}
+import com.github.vitalsoftware.scalaredox.models.{ Result, ResultsMessage }
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
 /**
-  * Created by apatzer on 3/23/17.
-  */
+ * Created by apatzer on 3/23/17.
+ */
 class ResultsTest extends Specification with NoTimeConversions with RedoxTest {
 
   "alter Results" should {


### PR DESCRIPTION
I have uncommented one VisitNumber field in VisitInfo class, which was commented because Redox were returning json numbers, not json strings for this fields. Now they fixed it.

Main change is in this commit: https://github.com/vital-software/scala-redox/pull/14/commits/d5aae30889d9e7f903dc9091e685ab57961255b1