### PR TITLE
Adds Upload method for sending file to redox

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.3",
   "com.typesafe.play" %% "play-json-joda" % "2.6.3",
-  "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.4",
+  "com.typesafe.play" %% "play-ahc-ws" % "2.6.3",
+//  "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.4",
   "com.typesafe.play" %% "play-ws-standalone-json" % "1.0.4",
   "com.typesafe.akka" %% "akka-http" % "10.0.9",
   //"ai.x" %% "play-json-extensions" % "0.8.0",

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/Response.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/Response.scala
@@ -28,7 +28,7 @@ case class RedoxResponse[T](result: Either[RedoxErrorResponse, T]) {
 
 object RedoxErrorResponse {
   val NotFound = simple("Error: JSON response not found")
-  def simple(msg: String) = RedoxErrorResponse(Seq(RedoxError(0, msg)))
+  def simple(msgs: String*) = RedoxErrorResponse(msgs.zipWithIndex.map(msg => RedoxError(msg._2, msg._1)))
   def fromJsError(jsError: JsError) = simple(JsError.toJson(jsError).toString())
 }
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Upload.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Upload.scala
@@ -1,0 +1,8 @@
+package com.github.vitalsoftware.scalaredox.models
+
+import com.github.vitalsoftware.macros._
+
+/**
+ * @author andrew.zurn@dexcom.com - 11/1/17.
+ */
+@jsonDefaults case class Upload(URI: String)

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
@@ -30,7 +30,7 @@ trait RedoxTest {
 
   def handleResponse[T](fut: Future[RedoxResponse[T]]): Option[T] = {
     val resp = Await.result(fut, 10.seconds)
-    if (resp.isError) throw new RuntimeException(resp.getError.Errors.map(_.Text).mkString(","))
+    if (resp.isError) throw new RuntimeException(resp.getError.Errors.map(_.Text).mkString(", "))
     resp.asOpt
   }
 }

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
@@ -1,0 +1,25 @@
+package com.github.vitalsoftware.scalaredox
+
+import java.nio.file.Files
+
+import org.specs2.mutable.Specification
+import org.specs2.time.NoTimeConversions
+
+/**
+ * @author andrew.zurn@dexcom.com - 11/1/17.
+ */
+class UploadTest extends Specification with NoTimeConversions with RedoxTest {
+
+  "alter Uploads" should {
+    "post new Uploads" in {
+      val file = Files.createTempFile("test-file", ".txt")
+      java.nio.file.Files.newOutputStream(file).write("This is a test".getBytes)
+
+      val fut = client.upload(file.toFile)
+      val maybe = handleResponse(fut)
+      maybe must beSome
+      maybe.get.URI must contain("https://blob.redoxengine.com")
+    }
+  }
+
+}


### PR DESCRIPTION
Fix for #16 

* Had to remove 'play-ahc-ws-standalone' in place of 'play-ahc-ws' % 2.6.3, as the Multipart objects (mainly `FilePart`) is not available in the standalone package currently (reference: https://github.com/playframework/play-ws/issues/126).
 * Followed directions from 'Sending Files Through Redox' page for requirements of client functionality (https://developer.redoxengine.com/data-exchange/sending-files-through-redox/).
 * The `upload` method has a few default parameters to it, one for the `fileContentType` that will be used by the Source stream during materialization, and one for `contentLength`. The default content length is to allow for a 2MB file upload (bytes in decimal octets). This is set as a request header, which the backing http client will then pick up and submit the entity as a whole, rather than chunking it (which looks like is required by the Redox endpoint). Reference: https://stackoverflow.com/a/38664501, play.api.libs.ws.ahc.StandaloneAhcWSRequest#buildRequest() line: 303.

All tests pass

Do you need me to manually bump the version? Or do you have a release process that will do that for you?