### PR TITLE
Move CI to Buildkite

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,0 +1,10 @@
+FROM quay.io/vital/scala:jdk-master
+
+ADD project /app/project
+ADD build.sbt /app
+
+# Grab any updated dependencies
+RUN sbt update
+
+# Add rest of sources
+ADD . /app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+  - label: ":docker: :sbt: Run tests"
+    command:
+      - docker build --tag scala-redox:${BUILDKITE_COMMIT} -f .buildkite/Dockerfile .
+      - docker run -e REDOX_API_SECRET -e REDOX_API_KEY scala-redox:${BUILDKITE_COMMIT} test

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.buildkite
+README.md
+LICENSE
+.gitignore
+.git/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scala-redox
 
-[ ![Codeship Status for vital-software/scala-redox](https://app.codeship.com/projects/e7ee7910-27a6-0135-d25d-5ece7f76f3e5/status?branch=master)](https://app.codeship.com/projects/223013)
+[![Build status](https://badge.buildkite.com/b0bbb5518c0cee6021cd4f31c5ac97537aa0a2a17bf88bee2b.svg)](https://buildkite.com/vital/scala-redox)
 
 Scala rest-client (Java compatible) for sending and receiving messages from the Redox healthcare APIs. Messages are sent
 and received asynchronously, returning Future[RedoxResponse[T]] objects that are either a type T or a RedoxErrorResponse 


### PR DESCRIPTION
* Build is still essentially `sbt test`
* Does the builds within a container (albeit one that isn't publicly available) for cleanliness