### PR TITLE
Base image no longer has sbt as Docker entrypoint

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,4 +2,4 @@ steps:
   - label: ":docker: :sbt: Run tests"
     command:
       - docker build --tag scala-redox:${BUILDKITE_COMMIT} -f .buildkite/Dockerfile .
-      - docker run -e REDOX_API_SECRET -e REDOX_API_KEY scala-redox:${BUILDKITE_COMMIT} test
+      - docker run -e REDOX_API_SECRET -e REDOX_API_KEY scala-redox:${BUILDKITE_COMMIT} sbt test


### PR DESCRIPTION
So, we include `sbt` in the run command instead