### PR TITLE
Upgrade play-json to 2.6.8, fix some types to agree with schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ name := "scala-redox"
 
 version := "0.95-SNAPSHOT"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.11.8", "2.11.9", "2.11.10", "2.11.11", "2.12.0", "2.12.1", "2.12.2")
+crossScalaVersions := Seq("2.11.8", "2.11.9", "2.11.10", "2.11.11", "2.11.12", "2.12.0", "2.12.1", "2.12.2")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),

--- a/build.sbt
+++ b/build.sbt
@@ -17,11 +17,11 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.6.7",
-  "com.typesafe.play" %% "play-json-joda" % "2.6.7",
-  "com.typesafe.play" %% "play-ahc-ws" % "2.6.7",
-  //"com.typesafe.play" %% "play-ahc-ws-standalone" % "1.1.3",
-  "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.3",
+  "com.typesafe.play" %% "play-json" % "2.6.8",
+  "com.typesafe.play" %% "play-json-joda" % "2.6.8",
+  "com.typesafe.play" %% "play-ahc-ws" % "2.6.12",
+  //"com.typesafe.play" %% "play-ahc-ws-standalone" % "1.1.6",
+  "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.6",
   "com.typesafe.akka" %% "akka-http" % "10.0.9",
   //"ai.x" %% "play-json-extensions" % "0.8.0",
   "com.github.vital-software" %% "json-annotation" % "0.4.0",

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/AdvanceDirective.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/AdvanceDirective.scala
@@ -20,8 +20,8 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class AdvanceDirective(
   Type: BasicCode,
-  Code: String, // Todo Question: Seems to duplicate 'Type' field
-  CodeSystem: String,
+  Code: Option[String] = None, // Todo Question: Seems to duplicate 'Type' field
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String],
   StartDate: DateTime,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -29,30 +29,30 @@ trait DateRange {
  * Code reference (like a foreign key into a SNOMED, ICD-9/10, or other data set)
  */
 trait Code {
-  def Code: String
-  def CodeSystem: String
+  def Code: Option[String]
+  def CodeSystem: Option[String]
   def CodeSystemName: Option[String]
   def Name: Option[String]
 }
 
 @jsonDefaults case class BasicCode(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None
 ) extends Code
 
 @jsonDefaults case class CodeWithText(
-  Code: String,
+  Code: Option[String] = None,
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Text: Option[String] = None
-)
+) extends Code
 
 @jsonDefaults case class CodeWithStatus(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Status: Option[String] = None,
@@ -143,8 +143,8 @@ object ValueTypes extends Enumeration {
  *                  @param Units The units of the measurement. [UCUM Units of Measure](http://unitsofmeasure.org/ucum.html)
  */
 @jsonDefaults case class Observation(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   DateTime: DateTime,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
@@ -18,8 +18,8 @@ import com.github.vitalsoftware.macros._
 )
 
 @jsonDefaults case class Relation(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Demographics: FamilyDemographics,
@@ -43,8 +43,8 @@ import com.github.vitalsoftware.macros._
  * @param Type The general class of the problem. (disease, problem, etc.).
  */
 @jsonDefaults case class FamilyHistoryProblem(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Type: BasicCode,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Immunization.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Immunization.scala
@@ -18,8 +18,8 @@ import com.github.vitalsoftware.macros._
  * @param LotNumber The lot number of the vaccine
  */
 @jsonDefaults case class ImmunizationProduct(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Manufacturer: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
@@ -20,8 +20,8 @@ import com.github.vitalsoftware.macros._
 @jsonDefaults case class Problem(
   StartDate: Option[DateTime] = None,
   EndDate: Option[DateTime] = None,
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Category: BasicCode,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
@@ -56,5 +56,5 @@ trait Person {
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
   EmailAddresses: Seq[String] = Seq.empty,
-  Credentials: Seq[String] = Seq.empty
+  Credentials: Option[String] = None
 ) extends Person

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -17,8 +17,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
  * @param Observations A list of corresponding observations for the test (result components)
  */
 @jsonDefaults case class ChartResult(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Status: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
@@ -14,8 +14,8 @@ import com.github.vitalsoftware.macros._
  * @param ValueText The observed value for the code
  */
 @jsonDefaults case class SocialHistoryObservation(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   StartDate: DateTime,
@@ -41,8 +41,8 @@ import com.github.vitalsoftware.macros._
  * @param EndDate Date status ended. If this is null, the status is current.
  */
 @jsonDefaults case class TobaccoUse(
-  Code: String,
-  CodeSystem: String,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   StartDate: Option[DateTime] = None,


### PR DESCRIPTION
Fixes #26

See [this file](https://github.com/playframework/playframework/blob/2.6.12/framework/project/Dependencies.scala) which defines the dependencies for play 2.6.12 (play-json versions are no longer in lock-step with the main framework's versions) for which versions we're upgrading to.