### PR TITLE
Set up sbt-release to perform release versioning (manually)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.97.0] - 2018-05-28
+
+### Changed
+
+- Version numbers now have a patch part, so we can indicate backward compatible changes
+
+### Added
+
+- Added sbt-release plugin
+- Added a CHANGELOG
+
+## [0.96] - 2018-05-28
+
+### Changed
+
+- `Order.ClinicalInfo.Code` changed from `String` to `Option[String]`
+- `Order.Provider.NPI` changed from `String` to `Option[String]`

--- a/build.sbt
+++ b/build.sbt
@@ -78,3 +78,19 @@ scalariformPreferences := scalariformPreferences.value
   .setPreference(DanglingCloseParenthesis, Force)
 // compile only unmanaged sources, not the generated (aka managed) sourced
 sourceDirectories in (Compile, scalariformFormat) := (unmanagedSourceDirectories in Compile).value
+
+// Release settings
+import ReleaseTransformations._
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+//  publishArtifacts,
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,6 @@ organization := "com.github.vital-software"
 
 name := "scala-redox"
 
-version := "0.97-SNAPSHOT"
-
 scalaVersion := "2.11.12"
 
 crossScalaVersions := Seq("2.11.8", "2.11.9", "2.11.10", "2.11.11", "2.11.12", "2.12.0", "2.12.1", "2.12.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.97-SNAPSHOT"


### PR DESCRIPTION
- Adds a changelog
- Sets up sbt-release
- Doesn't actually perform releases automatically; releasing is a matter of running `sbt release`