### PR TITLE
Make the null-subtree algorithm remove nulls from arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `Insurance.Plan` changed from `InsurancePlan` to `Option[InsurancePlan]`
+  - That's because the plan may be a "null subtree" (all properties null), in which case it is not guaranteed to be set
+- Null subtree algorithm removes nulls from arrays
+  - Previously, if null-subtree objects were wrapped in an array, the subtree removal would replace the objects with JsNull
+    values, but leave them in the array (causing a later error), e.g.
+
+    ```json
+    "Orders": [
+      {
+        "Diagnoses": [
+          {
+            "Code": null,
+            "Codeset": null,
+            "Name": null,
+            "Type": null
+          }
+        ]
+      }
+    ]
+    ```
+
+    previously became
+
+    ```json
+    "Orders": [
+      {
+        "Diagnoses": [null]
+      }
+    ]
+    ```
+
+    but will now become
+
+    ```json
+    "Orders": [
+      {
+        "Diagnoses": []
+      }
+    ]
+    ```
+
 ## [0.97] - 2018-05-28
 
 ### Changed

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
@@ -101,7 +101,7 @@ object InsuranceCoverageTypes extends Enumeration {
  * @param Insured Individual who has the agreement with the insurance company for the related policy
  */
 @jsonDefaults case class Insurance(
-  Plan: InsurancePlan,
+  Plan: Option[InsurancePlan] = None,
   Company: Option[InsuranceCompany] = None,
   GroupNumber: Option[String] = None,
   GroupName: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -94,7 +94,10 @@ trait JsonImplicits {
             JsObject(o.map { case (s, childVal) => s -> reduceNullSubtreesImpl(childVal) })
           }
         case JsArray(ts) =>
-          JsArray(ts.map(reduceNullSubtreesImpl))
+          JsArray(ts.map(reduceNullSubtreesImpl).filter(_ match {
+            case JsNull => false
+            case _      => true
+          }))
         case _ =>
           jv
       }

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
@@ -23,12 +23,15 @@ trait RedoxTest {
 
   // Validate raw a raw JSON string, throwing a RuntimeException which will output detail to Specs2/Test console
   def validateJsonInput[T](json: String)(implicit reads: Reads[T]): T = {
-    val jsValue = Json.parse(json).reduceNullSubtrees
     Json.parse(json).validate[T].fold(
       invalid = err => throw new RuntimeException(JsError.toJson(JsError(err)).toString()),
       valid = identity
     )
-    Json.fromJson[T](jsValue).get
+
+    Json.fromJson[T](Json.parse(json).reduceNullSubtrees).fold(
+      invalid = err => throw new RuntimeException(JsError.toJson(JsError(err)).toString()),
+      valid = identity
+    )
   }
 
   def handleResponse[T](fut: Future[RedoxResponse[T]]): Option[T] = {


### PR DESCRIPTION
- `Insurance.Plan` changed from `InsurancePlan` to `Option[InsurancePlan]`
  - That's because the plan may be a "null subtree" (all properties null), in which case it is not guaranteed to be set
- Null subtree algorithm now removes nulls from arrays
  - Previously, if null-subtree objects were wrapped in an array, the subtree removal would replace the objects with JsNull values, but leave them in the array (causing a later error), e.g.

    ```json
    "Orders": [
      {
        "Diagnoses": [
          {
            "Code": null,
            "Codeset": null,
            "Name": null,
            "Type": null
          }
        ]
      }
    ]
    ```

    previously became

    ```json
    "Orders": [
      {
        "Diagnoses": [null]
      }
    ]
    ```

    but will now become

    ```json
    "Orders": [
      {
        "Diagnoses": []
      }
    ]
    ```