### PR TITLE
Fixes for grouped order parsing and optional Patient.Demographics.Sex field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
   We now take both the `Meta.DataModel` and `Meta.EventType` into account when deciding how to parse a message.
 
+- `Patient.Demographics.Sex` now defaults to a value of `Unknown`. This was previously a required value, but Redox only
+  define it as "reliable" and not "required" (we've seen messages in-the-wild with `null` for this property.)
+
 ## [0.98] - 2018-05-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.99] - Unreleased
+
+### Changed
+
+- Messages were previously matched to a data type using the `Meta.DataModel` field only. However, this doesn't completely
+  determine the shape of the message; for example, a message with `DataModel == Order` may not have an `Order` key,
+  because `Meta.EventType` might be `GroupedOrders` (i.e. it has an `Orders` key, not an `Order` key).
+
+  We now take both the `Meta.DataModel` and `Meta.EventType` into account when deciding how to parse a message.
+
 ## [0.98] - 2018-05-28
 
 ### Changed

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -3,9 +3,9 @@ package com.github.vitalsoftware.scalaredox.client
 import java.io.File
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.Uri.Path._
+import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ FileIO, Source }
 import com.github.vitalsoftware.scalaredox._
@@ -14,15 +14,15 @@ import com.github.vitalsoftware.util.JsonImplicits.JsValueExtensions
 import com.typesafe.config.Config
 import org.joda.time.DateTime
 import play.api.libs.json._
-import play.api.libs.ws._
-import play.api.libs.ws.ahc._
 import play.api.libs.ws.JsonBodyReadables._
 import play.api.libs.ws.JsonBodyWritables._
+import play.api.libs.ws._
+import play.api.libs.ws.ahc._
 import play.api.mvc.MultipartFormData.FilePart
 
-import scala.concurrent.{ Future, SyncVar }
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.duration._
+import scala.concurrent.{ Future, SyncVar }
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -226,6 +226,10 @@ object RedoxClient {
       invalid = errors => Left(errors),
       valid = { meta =>
         meta.DataModel match {
+          case Order => meta.EventType match {
+            case GroupedOrders => json.validate[models.GroupedOrdersMessage].asEither
+            case _             => json.validate[models.OrderMessage].asEither
+          }
           case Claim => Left(unsupported)
           case Device => Left(unsupported)
           case Financial => Left(unsupported)
@@ -233,7 +237,6 @@ object RedoxClient {
           case Inventory => Left(unsupported)
           case Media => json.validate[models.MediaMessage].asEither
           case Notes => json.validate[models.NoteMessage].asEither
-          case Order => json.validate[models.OrderMessage].asEither
           case PatientAdmin => json.validate[models.PatientAdminMessage].asEither
           case PatientSearch => json.validate[models.PatientSearch].asEither
           case Referral => Left(unsupported)

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -45,7 +45,7 @@ object Gender extends Enumeration {
   LastName: String,
   DOB: DateTime,
   SSN: Option[String] = None,
-  Sex: Gender.Value,
+  Sex: Gender.Value = Gender.Unknown,
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
   EmailAddresses: Seq[String] = Seq.empty,

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/GroupedOrdersTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/GroupedOrdersTest.scala
@@ -1,6 +1,6 @@
 package com.github.vitalsoftware.scalaredox
 
-import com.github.vitalsoftware.scalaredox.models.{ GroupedOrdersMessage, Order }
+import com.github.vitalsoftware.scalaredox.models.{ Gender, GroupedOrdersMessage, Order }
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
@@ -50,7 +50,7 @@ class GroupedOrdersTest extends Specification with NoTimeConversions with RedoxT
           |      "LastName": "Bixby",
           |      "DOB": "2008-01-06",
           |      "SSN": "101-01-0001",
-          |      "Sex": "Male",
+          |      "Sex": null,
           |      "Race": "Asian",
           |      "IsHispanic": null,
           |      "MaritalStatus": "Single",
@@ -449,6 +449,10 @@ class GroupedOrdersTest extends Specification with NoTimeConversions with RedoxT
       visit.Guarantor.get.Employer must beSome
       visit.Insurances must not be empty
       visit.Location must beSome
+
+      val patient = data.Patient
+      patient.Demographics must beSome
+      patient.Demographics.get.Sex must beEqualTo(Gender.Unknown)
     }
   }
 }


### PR DESCRIPTION
## Purpose

Two separate issues fixed in this PR:

 - The `RedoxClient` wasn't considering the event type of order events, such that it would never parse a GroupedOrdersMessage
 - `Patient.Demographics.Sex` was a required field, but we've seen events where it is `null`

## Approach

 - Read `Meta.EventType` and use it (in combination with the existing `Meta.DataModel`) to decide how to parse a Redox message
 - Treat `null` values in `Patient.Demographics.Sex` the same as a value of `Unknown`