### PR TITLE
Add a HasVisitInfo trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased]
 
-## [0.102] - 2018-06-11
+### Added
 
-## [0.101] - 2018-06-08
+- Added a `HasVisitInfo` trait to mark models with a `Visit: Option[VisitInfo]` property.
 
-## [0.100] - 2018-06-08
+## [0.100] - [0.102] - 2018-06-11
+
+### Added
+
+- Initial and webhook support for the `Flowsheet` data model.
 
 ## [0.99] - 2018-06-01
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Document.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Document.scala
@@ -26,7 +26,7 @@ import com.github.vitalsoftware.macros._
   Title: String,
   DateTime: DateTime,
   Type: String
-)
+) extends HasVisitInfo
 
 /**
  * Information about the patient and where the summary came from

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/HasVisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/HasVisitInfo.scala
@@ -1,0 +1,5 @@
+package com.github.vitalsoftware.scalaredox.models
+
+trait HasVisitInfo {
+  def Visit: Option[VisitInfo]
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
@@ -48,4 +48,4 @@ object MediaAvailability extends Enumeration {
   Patient: Patient,
   Media: Media,
   Visit: Option[VisitInfo] = None
-) extends MetaLike with HasPatient
+) extends MetaLike with HasVisitInfo with HasPatient

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -63,4 +63,4 @@ object NoteContentTypes extends Enumeration {
   Visit: Option[VisitInfo] = None,
   Note: Note,
   Orders: Seq[NoteOrder] = Seq.empty
-) extends MetaLike with HasPatient
+) extends MetaLike with HasPatient with HasVisitInfo

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -123,7 +123,7 @@ object OrderPriorityTypes extends Enumeration {
   ClinicalInfo: Seq[ClinicalInfo] = Seq.empty
 )
 
-trait OrdersMessageLike extends HasPatient {
+trait OrdersMessageLike extends HasPatient with HasVisitInfo {
   def Meta: Meta
   def Patient: Patient
   def Visit: Option[VisitInfo]

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -105,4 +105,4 @@ object Gender extends Enumeration {
   Meta: Meta,
   Patient: Patient,
   Visit: Option[VisitInfo] = None
-) extends MetaLike with HasPatient
+) extends MetaLike with HasPatient with HasVisitInfo

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -129,4 +129,4 @@ object ResultsStatusTypes extends Enumeration {
   Patient: Patient,
   Orders: Seq[OrderResult] = Seq.empty,
   Visit: Option[VisitInfo] = None
-) extends MetaLike with HasPatient
+) extends MetaLike with HasPatient with HasVisitInfo


### PR DESCRIPTION
Adds a simple `HasVisitInfo` trait that marks models with a `Visit: Option[VisitInfo]` property