### PR TITLE
Allow better pruning of subtrees that are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a constructor argument to `RedoxClient`, `reducer` which allows specifying how to reduce e.g. empty
+  parts of a response before it is converted into model instances. Defaults to the current behavior, which is
+  to only prune parts of a response that are strictly null.
+- Added `reduceEmptySubtrees` as a method to `JsValue` (via implicits), in addition to the existing
+  `reduceNullSubtrees` that prunes null objects - the difference is that the "empty" variant also considers
+  arrays to be empty if they or their contents are (recursively).
+
 ## [0.103] - 2018-06-11
 
 ### Added

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -107,11 +107,11 @@ trait JsonImplicits {
 
     private def reduceEmptySubtreesImpl(jv: JsValue): JsValue = {
       jv match {
-        case JsObject(o) if o.valuesIterator.forall(isEmpty) => JsNull
-        case JsObject(o)                                     => JsObject(o.map { case (k, v) => k -> reduceEmptySubtreesImpl(v) })
-        case JsArray(a)  if a.forall(isEmpty)                => JsArray(Nil)
-        case JsArray(a)                                      => JsArray(a.map(reduceEmptySubtreesImpl))
-        case _                                               => jv
+        case _: JsObject if isEmpty(jv) => JsNull
+        case JsObject(o)                => JsObject(o.map { case (k, v) => k -> reduceEmptySubtreesImpl(v) })
+        case _: JsArray if isEmpty(jv)  => JsArray(Nil)
+        case JsArray(a)                 => JsArray(a.map(reduceEmptySubtreesImpl))
+        case _                          => jv
       }
     }
 

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -109,7 +109,7 @@ trait JsonImplicits {
       jv match {
         case _: JsObject if isEmpty(jv) => JsNull
         case JsObject(o)                => JsObject(o.map { case (k, v) => k -> reduceEmptySubtreesImpl(v) })
-        case _: JsArray if isEmpty(jv)  => JsArray(Nil)
+        case _: JsArray if isEmpty(jv)  => JsArray.empty
         case JsArray(a)                 => JsArray(a.map(reduceEmptySubtreesImpl))
         case _                          => jv
       }

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -108,10 +108,10 @@ trait JsonImplicits {
     private def reduceEmptySubtreesImpl(jv: JsValue): JsValue = {
       jv match {
         case JsObject(o) if o.valuesIterator.forall(isEmpty) => JsNull
-        case JsObject(o) => JsObject(o.map { case (k, v) => k -> reduceEmptySubtreesImpl(v) })
-        case JsArray(a) if a.forall(isEmpty) => JsArray(Nil)
-        case JsArray(a) => JsArray(a.map(reduceEmptySubtreesImpl))
-        case _ => jv
+        case JsObject(o)                                     => JsObject(o.map { case (k, v) => k -> reduceEmptySubtreesImpl(v) })
+        case JsArray(a)  if a.forall(isEmpty)                => JsArray(Nil)
+        case JsArray(a)                                      => JsArray(a.map(reduceEmptySubtreesImpl))
+        case _                                               => jv
       }
     }
 

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -107,11 +107,9 @@ trait JsonImplicits {
 
     private def reduceEmptySubtreesImpl(jv: JsValue): JsValue = {
       jv match {
-        case _: JsObject if isEmpty(jv) => JsNull
-        case JsObject(o)                => JsObject(o.map { case (k, v) => k -> reduceEmptySubtreesImpl(v) })
-        case _: JsArray if isEmpty(jv)  => JsArray.empty
-        case JsArray(a)                 => JsArray(a.map(reduceEmptySubtreesImpl))
-        case _                          => jv
+        case JsObject(o) => if (isEmpty(jv)) JsNull else JsObject(o.mapValues(reduceEmptySubtreesImpl))
+        case JsArray(a)  => if (isEmpty(jv)) JsArray.empty else JsArray(a.map(reduceEmptySubtreesImpl))
+        case _           => jv
       }
     }
 

--- a/src/test/scala/com/github/vitalsoftware/util/JsonOpsTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/JsonOpsTest.scala
@@ -1,0 +1,120 @@
+package com.github.vitalsoftware.util
+
+import com.github.vitalsoftware.util.JsonImplicits.JsValueExtensions
+import org.specs2.matcher.MatchResult
+import org.specs2.mutable.Specification
+import play.api.libs.json._
+
+class JsonOpsTest extends Specification {
+  def reduceEmpty(value: String, expected: String): MatchResult[String] = {
+    Json.parse(value).reduceEmptySubtrees.toString must beEqualTo(Json.parse(expected).toString)
+  }
+
+  def reduceNull(value: String, expected: String): MatchResult[String] = {
+    Json.parse(value).reduceNullSubtrees.toString must beEqualTo(Json.parse(expected).toString)
+  }
+
+  "JsonOps" should {
+    "JsValue.reduceNullSubtrees" in {
+      "null literal" in reduceNull("null", "null")
+      "empty object" in reduceNull("{}", "null")
+      "empty array" in reduceNull("[]", "[]")
+      "array of arrays" in reduceNull("[[], []]", "[[], []]")
+      "mixed empty array" in reduceNull("[null, []]", "[[]]")
+
+      "object with an empty array property and one non-empty" in reduceNull(
+        """
+          |{
+          |  "someEmpty": {
+          |    "emptyInner": {
+          |      "innerInner": null
+          |    },
+          |    "emptyArrayInner": [null]
+          |  },
+          |  "someDefined": "value",
+          |  "someEmptyArray": [[], {"emptyInner": null}, null]
+          |}
+        """.stripMargin,
+        """
+          |{
+          |  "someEmpty": {
+          |    "emptyInner": null,
+          |    "emptyArrayInner": []
+          |  },
+          |  "someDefined": "value",
+          |  "someEmptyArray": [[]]
+          |}
+        """.stripMargin
+      )
+    }
+
+    "JsValue.reduceEmptySubtrees" in {
+      "null literal" in reduceEmpty("null", "null")
+      "empty object" in reduceEmpty("{}", "null")
+      "empty array" in reduceEmpty("[]", "[]")
+      "array of arrays" in reduceEmpty("[[], []]", "[]")
+      "mixed empty array" in reduceEmpty("[null, []]", "[]")
+
+      "object with only empty values" in reduceEmpty(
+        """
+          |{
+          |  "allEmpty": null
+          |}
+        """.stripMargin,
+        "null"
+      )
+
+      "object with one non-empty property" in reduceEmpty(
+        """
+          |{
+          |  "someEmpty": {
+          |    "emptyInner": null
+          |  },
+          |  "someDefined": "value"
+          |}
+        """.stripMargin,
+        """
+          |{
+          |  "someEmpty": null,
+          |  "someDefined": "value"
+          |}
+        """.stripMargin
+      )
+
+      "object with an empty array property" in reduceEmpty(
+        """
+          |{
+          |  "someEmpty": {
+          |    "emptyInner": null,
+          |    "emptyArrayInner": []
+          |  },
+          |  "someEmptyArray": []
+          |}
+        """.stripMargin,
+        "null"
+      )
+
+      "object with an empty array property and one non-empty" in reduceEmpty(
+        """
+          |{
+          |  "someEmpty": {
+          |    "emptyInner": {
+          |      "innerInner": null
+          |    },
+          |    "emptyArrayInner": [null]
+          |  },
+          |  "someDefined": "value",
+          |  "someEmptyArray": [[], {"emptyInner": null}, null]
+          |}
+        """.stripMargin,
+        """
+          |{
+          |  "someEmpty": null,
+          |  "someDefined": "value",
+          |  "someEmptyArray": []
+          |}
+        """.stripMargin
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

We've been seeing testing messages from Redox that have quite sparse values. Sometimes we see even quite reliable fields come through as `null` (e.g. LastName), so we need to be quite good at pruning these subtrees.

The existing pruning approach didn't cope well with empty arrays as properties of an object.

## Approach

- Adds a new JsValue method: `reduceEmptySubtrees`
- Adds a new `JsonOpsTest` to test both the empty and null reducers
- Adds a new optional constructor parameter to the `RedoxClient` allowing the `reducer: JsValue => JsValue`) to be specified
  - Default value is `reduceNullSubtrees`, so this PR is completely BC (and new parameter is at end of list for anyone who was specifying the implicit parameters already)

So, to use the new pruning, you'd:

```scala
val client = new RedoxClient(config, reducer = _.reduceEmptySubtrees)
```

### reduceEmptySubtrees versus reduceNullSubtrees

From the test, given this JSON:

```json
{                                                    
  "someEmpty": {                                     
    "emptyInner": {                                  
      "innerInner": null                             
    },                                               
    "emptyArrayInner": [null]                        
  },                                                 
  "someDefined": "value",                            
  "someEmptyArray": [[], {"emptyInner": null}, null] 
}                                                    
```

the old ("null") approach produces:

```json
{                         
  "someEmpty": {          
    "emptyInner": null,   
    "emptyArrayInner": [] 
  },                      
  "someDefined": "value", 
  "someEmptyArray": [[]]  
}                         
```

and the new ("empty") approach produces:

```json
{                        
  "someEmpty": null,     
  "someDefined": "value",
  "someEmptyArray": []   
}                        
```