### PR TITLE
Add a reducer argument to RedoxClient.webhook()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Optional reducer argument to `RedoxClient.webhook`, similar to the one on the `RedoxClient` constructor
+
 ## [0.104] - 2018-06-12
 
 ### Added


### PR DESCRIPTION
In a previous PR, we added a reducer argument to the RedoxClient constructor, allowing the user of the client to prune or otherwise alter a JsValue to their taste.