### PR TITLE
Perform Sonatype release correctly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,9 +94,10 @@ releaseProcess := Seq[ReleaseStep](
   updateReleaseFiles,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
+  releaseStepCommandAndRemaining("+publishSigned"),
   setNextVersion,
   commitNextVersion,
+  releaseStepCommand("sonatypeReleaseAll"),
   pushChanges
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")


### PR DESCRIPTION
Relates to #33

Configuration taken from https://github.com/xerial/sbt-sonatype#using-with-sbt-release-plugin - previously, we were relying on publishArtifacts which does "auto-staging", and wouldn't get promoted (because things weren't signed with PGP)

Also, with the new version of sbt-sonatype we can set credentials using env vars.