### PR TITLE
Perform automated releases in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,3 +3,18 @@ steps:
     command:
       - docker build --tag scala-redox:${BUILDKITE_COMMIT} -f .buildkite/Dockerfile .
       - docker run -e REDOX_API_SECRET -e REDOX_API_KEY scala-redox:${BUILDKITE_COMMIT} sbt test
+
+  - wait
+
+  - block:    ":rocket: Release"
+    prompt:   Create a release, and push it to Sonatype and Github?
+    branches: "master"
+
+  - label: ":maven: :sbt: Create release"
+    command:
+      - git checkout -B ${BUILDKITE_BRANCH}
+      - git branch -u origin/${BUILDKITE_BRANCH}
+      - git config branch.${BUILDKITE_BRANCH}.remote origin
+      - git config branch.${BUILDKITE_BRANCH}.merge refs/heads/${BUILDKITE_BRANCH}
+      - git clean -df
+      - sbt -batch "release with-defaults skip-tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,7 @@ steps:
     branches: "master"
 
   - label: ":maven: :sbt: Create release"
+    branches: "master"
     command:
       - git checkout -B ${BUILDKITE_BRANCH}
       - git branch -u origin/${BUILDKITE_BRANCH}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Releases are now performed by CI automatically
+- Cross-build Scala versions updated to the latest in each of 2.11.x/2.12.x
+
 ### Added
 
 - Optional reducer argument to `RedoxClient.webhook`, similar to the one on the `RedoxClient` constructor

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,11 @@
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import scalariform.formatter.preferences._
+
+import scala.io.{ Codec, Source }
+import scala.sys.process.ProcessLogger
 
 organization := "com.github.vital-software"
 
@@ -6,7 +13,7 @@ name := "scala-redox"
 
 scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.11.8", "2.11.9", "2.11.10", "2.11.11", "2.11.12", "2.12.0", "2.12.1", "2.12.2")
+crossScalaVersions := Seq("2.11.12", "2.12.6")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
@@ -77,14 +84,14 @@ scalariformPreferences := scalariformPreferences.value
 // compile only unmanaged sources, not the generated (aka managed) sourced
 sourceDirectories in (Compile, scalariformFormat) := (unmanagedSourceDirectories in Compile).value
 
-// Release settings
-import ReleaseTransformations._
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import scala.io.{ Codec, Source }
-import scala.sys.process.ProcessLogger
+// PGP settings
+pgpPassphrase := Some(Array())
+usePgpKeyHex("1bfe664d074b29f8")
 
-releaseTagName := s"${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}" // Remove v prefix
+// Release settings
+releaseTagName              := s"${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}" // Remove v prefix
+releaseTagComment           := s"Releasing ${(version in ThisBuild).value}\n\n[skip ci]"
+releaseCommitMessage        := s"Setting version to ${(version in ThisBuild).value}\n\n[skip ci]"
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.105-SNAPSHOT"
+version in ThisBuild := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
## Purpose

Fixes #33

## Approach

- Normal master builds don't cause a release
- Adds a "block step", which allows a developer to click the "release" button to cause an automated release from that build
- Reduces the number of cross-build versions we use (many were the same binary version anyway)
- Bumps the major version to 1