### PR TITLE
Per vital-software/api#938, rename "gender" to "sex".

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
@@ -13,7 +13,7 @@ import com.github.vitalsoftware.macros._
  * @param DOB Date of Birth of the relative. In YYYY-MM-DD format
  */
 @jsonDefaults case class FamilyDemographics(
-  Sex: Gender.Value,
+  Sex: SexType.Value,
   DOB: Option[LocalDate] = None
 )
 
@@ -31,7 +31,7 @@ import com.github.vitalsoftware.macros._
  * @param DOB Date of Birth of the relative. In YYYY-MM-DD format
  */
 @jsonDefaults case class RelationDemographics(
-  Sex: Gender.Value,
+  Sex: SexType.Value,
   DOB: LocalDate
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -21,9 +21,9 @@ import play.api.libs.json.{ Format, Reads, Writes }
   IDType: String
 )
 
-object Gender extends Enumeration {
-  val M, F, Male, Female, Unknown, Other = Value
-  implicit lazy val jsonFormat: Format[Gender.Value] = Format(Reads.enumNameReads(Gender), Writes.enumNameWrites)
+object SexType extends Enumeration {
+  val Male, Female, Unknown, Other = Value
+  implicit lazy val jsonFormat: Format[SexType.Value] = Format(Reads.enumNameReads(SexType), Writes.enumNameWrites)
 }
 
 /**
@@ -45,7 +45,7 @@ object Gender extends Enumeration {
   LastName: String,
   DOB: DateTime,
   SSN: Option[String] = None,
-  Sex: Gender.Value = Gender.Unknown,
+  Sex: SexType.Value = SexType.Unknown,
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
   EmailAddresses: Seq[String] = Seq.empty,

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -19,7 +19,7 @@ class ClinicalSummaryTest extends Specification with NoTimeConversions with Redo
     "return an error" in {
       val shouldFailQuery = PatientQuery(
         Meta(DataModel = DataModelTypes.ClinicalSummary, EventType = RedoxEventTypes.Query),
-        Patient(Demographics = Some(Demographics("John", "Doe", DateTime.parse("1970-1-1"), Sex = Gender.Male)))
+        Patient(Demographics = Some(Demographics("John", "Doe", DateTime.parse("1970-1-1"), Sex = SexType.Male)))
       )
       val fut = client.get[PatientQuery, ClinicalSummary](shouldFailQuery)
       val resp = Await.result(fut, timeout)

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/GroupedOrdersTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/GroupedOrdersTest.scala
@@ -1,6 +1,6 @@
 package com.github.vitalsoftware.scalaredox
 
-import com.github.vitalsoftware.scalaredox.models.{ Gender, GroupedOrdersMessage, Order }
+import com.github.vitalsoftware.scalaredox.models.{ SexType, GroupedOrdersMessage, Order }
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
@@ -452,7 +452,7 @@ class GroupedOrdersTest extends Specification with NoTimeConversions with RedoxT
 
       val patient = data.Patient
       patient.Demographics must beSome
-      patient.Demographics.get.Sex must beEqualTo(Gender.Unknown)
+      patient.Demographics.get.Sex must beEqualTo(SexType.Unknown)
     }
   }
 }


### PR DESCRIPTION
Also removes duplicate types "M" and "F" which are no longer supported by Redox.