### PR TITLE
Upgrade to SBT 1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
+ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 publishMavenStyle := true
 
@@ -48,7 +48,7 @@ publishTo := {
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 pomIncludeRepository := { _ => false }
 
@@ -82,16 +82,16 @@ scalariformPreferences := scalariformPreferences.value
   .setPreference(DoubleIndentConstructorArguments, false)
   .setPreference(DanglingCloseParenthesis, Force)
 // compile only unmanaged sources, not the generated (aka managed) sourced
-sourceDirectories in (Compile, scalariformFormat) := (unmanagedSourceDirectories in Compile).value
+Compile / scalariformFormat / sourceDirectories := (Compile / unmanagedSourceDirectories).value
 
 // PGP settings
 pgpPassphrase := Some(Array())
 usePgpKeyHex("1bfe664d074b29f8")
 
 // Release settings
-releaseTagName              := s"${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}" // Remove v prefix
-releaseTagComment           := s"Releasing ${(version in ThisBuild).value}\n\n[skip ci]"
-releaseCommitMessage        := s"Setting version to ${(version in ThisBuild).value}\n\n[skip ci]"
+releaseTagName              := s"${if (releaseUseGlobalVersion.value) (ThisBuild / version).value else version.value}" // Remove v prefix
+releaseTagComment           := s"Releasing ${(ThisBuild / version).value}\n\n[skip ci]"
+releaseCommitMessage        := s"Setting version to ${(ThisBuild / version).value}\n\n[skip ci]"
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-SNAPSHOT"
+ThisBuild / version := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
- Upgrade SBT to 1.1.6
- One plugin upgraded
- Fix for breaking changes (in SBT 1.0) to use `/` for specifying coordinates, instead of `in`