### PR TITLE
Upgrade specs2 to the latest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ organization := "com.github.vital-software"
 
 name := "scala-redox"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.6"
 
 crossScalaVersions := Seq("2.11.12", "2.12.6")
 
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   //"ai.x" %% "play-json-extensions" % "0.8.0",
   "com.github.vital-software" %% "json-annotation" % "0.4.5",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",
-  "org.specs2" %% "specs2" % "2.3.13" % Test
+  "org.specs2" %% "specs2-core" % "4.2.0" % Test
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
+ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 publishMavenStyle := true
 
@@ -48,7 +48,7 @@ publishTo := {
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 pomIncludeRepository := { _ => false }
 
@@ -82,16 +82,16 @@ scalariformPreferences := scalariformPreferences.value
   .setPreference(DoubleIndentConstructorArguments, false)
   .setPreference(DanglingCloseParenthesis, Force)
 // compile only unmanaged sources, not the generated (aka managed) sourced
-sourceDirectories in (Compile, scalariformFormat) := (unmanagedSourceDirectories in Compile).value
+Compile / scalariformFormat / sourceDirectories := (Compile / unmanagedSourceDirectories).value
 
 // PGP settings
 pgpPassphrase := Some(Array())
 usePgpKeyHex("1bfe664d074b29f8")
 
 // Release settings
-releaseTagName              := s"${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}" // Remove v prefix
-releaseTagComment           := s"Releasing ${(version in ThisBuild).value}\n\n[skip ci]"
-releaseCommitMessage        := s"Setting version to ${(version in ThisBuild).value}\n\n[skip ci]"
+releaseTagName              := s"${if (releaseUseGlobalVersion.value) (ThisBuild / version).value else version.value}" // Remove v prefix
+releaseTagComment           := s"Releasing ${(ThisBuild / version).value}\n\n[skip ci]"
+releaseCommitMessage        := s"Setting version to ${(ThisBuild / version).value}\n\n[skip ci]"
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -4,7 +4,6 @@ import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models._
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -12,7 +11,7 @@ import scala.concurrent.duration._
 /**
  * Created by apatzer on 3/23/17.
  */
-class ClinicalSummaryTest extends Specification with NoTimeConversions with RedoxTest {
+class ClinicalSummaryTest extends Specification with RedoxTest {
 
   "query ClinicalSummary" should {
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
@@ -4,13 +4,12 @@ import com.github.vitalsoftware.scalaredox.client.AuthInfo
 import com.github.vitalsoftware.scalaredox.models._
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 import play.api.libs.json.{ JsError, Json }
 
 import concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
-class ConnectionTest extends Specification with NoTimeConversions with RedoxTest {
+class ConnectionTest extends Specification with RedoxTest {
 
   protected def validateAuth(auth: AuthInfo): Boolean = {
     auth.accessToken must not be empty

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/FlowSheetTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/FlowSheetTest.scala
@@ -3,9 +3,8 @@ package com.github.vitalsoftware.scalaredox
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models.FlowSheetMessage
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
-class FlowSheetTest extends Specification with NoTimeConversions with RedoxTest {
+class FlowSheetTest extends Specification with RedoxTest {
 
   "alter Flowsheet" should {
     "post new Flowsheet results" in {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/GroupedOrdersTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/GroupedOrdersTest.scala
@@ -2,9 +2,8 @@ package com.github.vitalsoftware.scalaredox
 
 import com.github.vitalsoftware.scalaredox.models.{ SexType, GroupedOrdersMessage, Order }
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
-class GroupedOrdersTest extends Specification with NoTimeConversions with RedoxTest {
+class GroupedOrdersTest extends Specification with RedoxTest {
   "alter GroupedOrders" should {
     "post a new GroupedOrders given Redox Dev Tools" in {
       val json =

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/MediaTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/MediaTest.scala
@@ -3,12 +3,11 @@ package com.github.vitalsoftware.scalaredox
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models.MediaMessage
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
 /**
  * Created by apatzer on 3/23/17.
  */
-class MediaTest extends Specification with NoTimeConversions with RedoxTest {
+class MediaTest extends Specification with RedoxTest {
 
   "alter Media" should {
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/NotesTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/NotesTest.scala
@@ -3,12 +3,11 @@ package com.github.vitalsoftware.scalaredox
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models.NoteMessage
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
 /**
  * Created by apatzer on 3/23/17.
  */
-class NotesTest extends Specification with NoTimeConversions with RedoxTest {
+class NotesTest extends Specification with RedoxTest {
 
   "alter Notes" should {
     "post new Notes" in {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/OrderTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/OrderTest.scala
@@ -3,12 +3,11 @@ package com.github.vitalsoftware.scalaredox
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models.OrderMessage
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
 /**
  * Created by apatzer on 3/23/17.
  */
-class OrderTest extends Specification with NoTimeConversions with RedoxTest {
+class OrderTest extends Specification with RedoxTest {
 
   "alter Orders" should {
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/PatientSearchTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/PatientSearchTest.scala
@@ -2,7 +2,6 @@ package com.github.vitalsoftware.scalaredox
 
 import com.github.vitalsoftware.scalaredox.models._
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -10,7 +9,7 @@ import scala.concurrent.duration._
 /**
  * Created by apatzer on 3/23/17.
  */
-class PatientSearchTest extends Specification with NoTimeConversions with RedoxTest {
+class PatientSearchTest extends Specification with RedoxTest {
 
   "query PatientSearch" should {
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ResultsTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ResultsTest.scala
@@ -3,12 +3,11 @@ package com.github.vitalsoftware.scalaredox
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
 import com.github.vitalsoftware.scalaredox.models.{ Result, ResultsMessage }
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
 /**
  * Created by apatzer on 3/23/17.
  */
-class ResultsTest extends Specification with NoTimeConversions with RedoxTest {
+class ResultsTest extends Specification with RedoxTest {
 
   "alter Results" should {
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
@@ -3,12 +3,11 @@ package com.github.vitalsoftware.scalaredox
 import java.nio.file.Files
 
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 
 /**
  * @author andrew.zurn@dexcom.com - 11/1/17.
  */
-class UploadTest extends Specification with NoTimeConversions with RedoxTest {
+class UploadTest extends Specification with RedoxTest {
 
   "alter Uploads" should {
     "post new Uploads" in {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-SNAPSHOT"
+ThisBuild / version := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
Builds on #48 
Fixes #47 

Upgrades specs2 to 4.2.0, which has a version available for Scala 2.12, fixing our cross-build release process

Probably the only interesting thing is that we no longer need the `NoTimeConversions` trait