### PR TITLE
Feature/enum sensible default fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [1.2.0]
+
+### Changed
+
+- Failing to parse an `Enumeration` with `HasDefaultReads` will now fallback to a default value
+and a failure being logged. (except for `SexType`, `DataModel`, `RedoxEventTypes` and `CommonVitalTypes`)
 
 ## [1.1.0] - 2018-06-28
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.HasDefaultReads
 import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
@@ -126,12 +127,13 @@ trait Code {
   Text: Option[String] = None
 )
 
-object ValueTypes extends Enumeration {
+object ValueTypes extends Enumeration with HasDefaultReads {
   val Numeric, String, Date, Time, DateTime = Value
   val CodedEntry = Value("Coded Entry")
   val EncapsulatedData = Value("Encapsulated Data")
 
-  implicit lazy val jsonFormat: Format[ValueTypes.Value] = Format(Reads.enumNameReads(ValueTypes), Writes.enumNameWrites)
+  val defaultValue = String
+  implicit lazy val jsonFormat: Format[ValueTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.LocalDate
 import com.github.vitalsoftware.util.JsonImplicits.jodaLocalDateFormat
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.HasDefaultReads
 import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
@@ -37,19 +38,25 @@ import play.api.libs.json.{ Format, Reads, Writes }
   PhoneNumber: Option[String] = None
 )
 
-object InsuranceRelationshipTypes extends Enumeration {
+object InsuranceRelationshipTypes extends Enumeration with HasDefaultReads {
   val Self, Spouse, Other = Value
-  implicit lazy val jsonFormat: Format[InsuranceRelationshipTypes.Value] = Format(Reads.enumNameReads(InsuranceRelationshipTypes), Writes.enumNameWrites)
+
+  val defaultValue = Other
+  implicit lazy val jsonFormat: Format[InsuranceRelationshipTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
-object InsuranceAgreementTypes extends Enumeration {
-  val Standard, Unified, Maternity = Value
-  implicit lazy val jsonFormat: Format[InsuranceAgreementTypes.Value] = Format(Reads.enumNameReads(InsuranceAgreementTypes), Writes.enumNameWrites)
+object InsuranceAgreementTypes extends Enumeration  with HasDefaultReads {
+  val Standard, Unified, Maternity, Other = Value
+
+  val defaultValue = Other
+  implicit lazy val jsonFormat: Format[InsuranceAgreementTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
-object InsuranceCoverageTypes extends Enumeration {
+object InsuranceCoverageTypes extends Enumeration with HasDefaultReads {
   val Patient, Clinic, Insurance, Other = Value
-  implicit lazy val jsonFormat: Format[InsuranceCoverageTypes.Value] = Format(Reads.enumNameReads(InsuranceCoverageTypes), Writes.enumNameWrites)
+
+  val defaultValue = Other
+  implicit lazy val jsonFormat: Format[InsuranceCoverageTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
 /** Individual who has the agreement with the insurance company for the related policy */

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
@@ -45,7 +45,7 @@ object InsuranceRelationshipTypes extends Enumeration with HasDefaultReads {
   implicit lazy val jsonFormat: Format[InsuranceRelationshipTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
-object InsuranceAgreementTypes extends Enumeration  with HasDefaultReads {
+object InsuranceAgreementTypes extends Enumeration with HasDefaultReads {
   val Standard, Unified, Maternity, Other = Value
 
   val defaultValue = Other

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
@@ -1,6 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.HasDefaultReads
 import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
@@ -9,9 +10,11 @@ import play.api.libs.json.{ Format, Reads, Writes }
  * Created by apatzer on 3/23/17.
  */
 
-object MediaAvailability extends Enumeration {
+object MediaAvailability extends Enumeration with HasDefaultReads {
   val Available, Unavailable = Value
-  implicit lazy val jsonFormat: Format[MediaAvailability.Value] = Format(Reads.enumNameReads(MediaAvailability), Writes.enumNameWrites)
+
+  val defaultValue = Unavailable
+  implicit lazy val jsonFormat: Format[MediaAvailability.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -2,6 +2,7 @@ package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.util.JsonImplicits._
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.HasDefaultReads
 import org.joda.time.DateTime
 import play.api.libs.json.{ Format, Reads, Writes }
 
@@ -9,11 +10,13 @@ import play.api.libs.json.{ Format, Reads, Writes }
  * Created by apatzer on 3/23/17.
  */
 
-object NoteContentTypes extends Enumeration {
+object NoteContentTypes extends Enumeration with HasDefaultReads {
   val PlainText = Value("Plain Text")
   val RichText = Value("Rich Text")
   val Base64 = Value("Base64 Encoded")
-  implicit lazy val jsonFormat: Format[NoteContentTypes.Value] = Format(Reads.enumNameReads(NoteContentTypes), Writes.enumNameWrites)
+
+  val defaultValue = PlainText
+  implicit lazy val jsonFormat: Format[NoteContentTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import java.time.LocalDate
 
 import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.HasDefaultReads
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import org.joda.time.DateTime
 import play.api.libs.json.{ Format, Reads, Writes }
@@ -25,14 +26,16 @@ import play.api.libs.json.{ Format, Reads, Writes }
   ID: Option[String] = None
 )
 
-object OrderPriorityTypes extends Enumeration {
+object OrderPriorityTypes extends Enumeration with HasDefaultReads {
   val Stat = Value("Stat")
   val ASAP = Value("ASAP")
   val Routine = Value("Routine")
   val Preoperative = Value("Preoperative")
   val TimingCritical = Value("Timing Critical")
+  val Other = Value("Other")
 
-  implicit lazy val jsonFormat: Format[OrderPriorityTypes.Value] = Format(Reads.enumNameReads(OrderPriorityTypes), Writes.enumNameWrites)
+  val defaultValue = Other
+  implicit lazy val jsonFormat: Format[OrderPriorityTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -1,6 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.HasDefaultReads
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import org.joda.time.DateTime
 import play.api.libs.json.{ Format, Reads, Writes }
@@ -81,11 +82,12 @@ import play.api.libs.json.{ Format, Reads, Writes }
 )
 
 // Current overall status of the order. One of the following: "Final", "Preliminary", "In Process", "Corrected", "Canceled".
-object ResultsStatusTypes extends Enumeration {
-  val Final, Preliminary, Corrected, Canceled = Value
+object ResultsStatusTypes extends Enumeration with HasDefaultReads {
+  val Final, Preliminary, Corrected, Canceled, Other = Value
   val InProcess = Value("In Process")
 
-  implicit lazy val jsonFormat: Format[ResultsStatusTypes.Value] = Format(Reads.enumNameReads(ResultsStatusTypes), Writes.enumNameWrites)
+  val defaultValue = Other
+  implicit lazy val jsonFormat: Format[ResultsStatusTypes.Value] = Format(defaultReads, Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -132,11 +132,14 @@ trait LowPriorityBaseEnumReads { self: Enumeration =>
   implicit lazy val baseEnumReads: Reads[self.Value] = Reads.enumNameReads(self).asInstanceOf[Reads[self.Value]]
 }
 
-trait HasDefaultReads extends LowPriorityBaseEnumReads with HasDefault { self: Enumeration with HasDefault =>
+trait HasDefaultReads extends LowPriorityBaseEnumReads with HasDefault with Logger { self: Enumeration with HasDefault =>
   implicit lazy val defaultReads: Reads[Value] = new Reads[Value] {
     override def reads(json: JsValue): JsResult[Value] = baseEnumReads.reads(json)
       .recover {
-        case err: JsError => self.defaultValue
+        case err: JsError => {
+          logger.error("Failed to parse enum value", JsResult.Exception(err))
+          self.defaultValue
+        }
       }
   }
 }

--- a/src/main/scala/com/github/vitalsoftware/util/Logger.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/Logger.scala
@@ -1,0 +1,6 @@
+package com.github.vitalsoftware.util
+
+trait Logger {
+  val logger = play.api.Logger(this.getClass)
+}
+

--- a/src/test/scala/com/github/vitalsoftware/util/JsonOpsTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/JsonOpsTest.scala
@@ -116,5 +116,22 @@ class JsonOpsTest extends Specification {
         """.stripMargin
       )
     }
+
+    "Enumeration with HasDefault" should {
+
+      object TestEnum extends Enumeration with HasDefaultReads {
+        val V1, V2, V3, Default = Value
+
+        override def defaultValue: TestEnum.Value = Default
+      }
+
+      "Use default value if it can't parse" in {
+        JsString("Unknown").validate[TestEnum.Value] mustEqual JsSuccess(TestEnum.Default)
+      }
+
+      "It works with correctly parsed values" in {
+        JsString("V1").validate[TestEnum.Value] mustEqual JsSuccess(TestEnum.V1)
+      }
+    }
   }
 }


### PR DESCRIPTION
Resolves #51 

Mixing `HasDefaultReads` with an Enumaration, gives it a default implicit `Reads[T]` that falls back to the defined default value if it fails to parse.

I've added the some default fallbacks to most of the enumerations except for `SexType`, `DataModel`, `RedoxEventTypes` and `CommonVitalTypes`