### PR TITLE
Fallback to defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- With the upgrade of `json-annotations` library. We will now assign default values to message fields
+whenever parsing of that filed fails.
+
 ### Changed
 
 - Failing to parse an `Enumeration` with `HasDefaultReads` will now fallback to a default value

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.6",
   "com.typesafe.akka" %% "akka-http" % "10.0.9",
   //"ai.x" %% "play-json-extensions" % "0.8.0",
-  "com.github.vital-software" %% "json-annotation" % "0.4.5",
+  "com.github.vital-software" %% "json-annotation" % "0.5.0",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",
   "org.specs2" %% "specs2-core" % "4.2.0" % Test
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/AdvanceDirective.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/AdvanceDirective.scala
@@ -19,7 +19,7 @@ import com.github.vitalsoftware.macros._
  * @param Custodians People legally responsible for the advance directive document.
  */
 @jsonDefaults case class AdvanceDirective(
-  Type: BasicCode,
+  Type: BasicCode = BasicCode(),
   Code: Option[String] = None, // Todo Question: Seems to duplicate 'Type' field
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Allergy.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Allergy.scala
@@ -20,11 +20,11 @@ import com.github.vitalsoftware.macros._
  * @param Comment Free text comment about the allergy.
  */
 @jsonDefaults case class Allergy(
-  Type: BasicCode,
-  Substance: BasicCode,
+  Type: BasicCode = BasicCode(),
+  Substance: BasicCode = BasicCode(),
   Reaction: Seq[CodeWithText] = Seq.empty,
-  Severity: BasicCode,
-  Status: BasicCode,
+  Severity: BasicCode = BasicCode(),
+  Status: BasicCode = BasicCode(),
   StartDate: Option[DateTime] = None,
   EndDate: Option[DateTime] = None,
   Comment: Option[String] = None

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -85,7 +85,7 @@ trait Code {
  * Note: Seems duplicative of CareLocation, but described using the generic 'Code' object
  */
 @jsonDefaults case class Location(
-  Address: Address = Address.apply(),
+  Address: Address,
   Type: BasicCode = BasicCode(),
   Name: Option[String] = None
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -85,8 +85,8 @@ trait Code {
  * Note: Seems duplicative of CareLocation, but described using the generic 'Code' object
  */
 @jsonDefaults case class Location(
-  Address: Address,
-  Type: BasicCode,
+  Address: Address = Address(),
+  Type: BasicCode = BasicCode(),
   Name: Option[String] = None
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -85,7 +85,7 @@ trait Code {
  * Note: Seems duplicative of CareLocation, but described using the generic 'Code' object
  */
 @jsonDefaults case class Location(
-  Address: Address = Address(),
+  Address: Address = Address.apply(),
   Type: BasicCode = BasicCode(),
   Name: Option[String] = None
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Document.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Document.scala
@@ -22,7 +22,7 @@ import com.github.vitalsoftware.macros._
   ID: String,
   Author: Option[Provider] = None, // Todo Provider.Type is not present!
   Visit: Option[VisitInfo] = None,
-  Locale: String, // TODO java.util.Locale
+  Locale: String = java.util.Locale.ROOT.toString, // TODO java.util.Locale
   Title: String,
   DateTime: DateTime,
   Type: String

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Encounter.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Encounter.scala
@@ -20,7 +20,7 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class Encounter(
   Identifiers: Seq[Identifier] = Seq.empty,
-  Type: BasicCode,
+  Type: BasicCode = BasicCode(),
   DateTime: DateTime,
   EndDateTime: Option[DateTime] = None,
   Providers: Seq[Provider] = Seq.empty,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
@@ -31,7 +31,7 @@ import com.github.vitalsoftware.macros._
  * @param DOB Date of Birth of the relative. In YYYY-MM-DD format
  */
 @jsonDefaults case class RelationDemographics(
-  Sex: SexType.Value = SexType.defaultValue,,
+  Sex: SexType.Value = SexType.defaultValue,
   DOB: LocalDate
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
@@ -54,7 +54,7 @@ import com.github.vitalsoftware.macros._
 ) extends Code
 
 @jsonDefaults case class FamilyHistory(
-  Relation: Relation = Relation(),
+  Relation: Relation = Relation.apply(),
   Problems: Seq[FamilyHistoryProblem] = Seq.empty
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
@@ -13,7 +13,7 @@ import com.github.vitalsoftware.macros._
  * @param DOB Date of Birth of the relative. In YYYY-MM-DD format
  */
 @jsonDefaults case class FamilyDemographics(
-  Sex: SexType.Value,
+  Sex: SexType.Value = SexType.defaultValue,
   DOB: Option[LocalDate] = None
 )
 
@@ -22,7 +22,7 @@ import com.github.vitalsoftware.macros._
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
-  Demographics: FamilyDemographics,
+  Demographics: FamilyDemographics = FamilyDemographics(),
   IsDeceased: Option[Boolean] = None
 ) extends Code
 
@@ -31,7 +31,7 @@ import com.github.vitalsoftware.macros._
  * @param DOB Date of Birth of the relative. In YYYY-MM-DD format
  */
 @jsonDefaults case class RelationDemographics(
-  Sex: SexType.Value,
+  Sex: SexType.Value = SexType.defaultValue,,
   DOB: LocalDate
 )
 
@@ -47,14 +47,14 @@ import com.github.vitalsoftware.macros._
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
-  Type: BasicCode,
+  Type: BasicCode = BasicCode(),
   DateTime: Option[DateTime] = None,
   AgeAtOnset: Option[String] = None,
   IsCauseOfDeath: Option[Boolean] = None
 ) extends Code
 
 @jsonDefaults case class FamilyHistory(
-  Relation: Relation,
+  Relation: Relation = Relation(),
   Problems: Seq[FamilyHistoryProblem] = Seq.empty
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
@@ -54,7 +54,7 @@ import com.github.vitalsoftware.macros._
 ) extends Code
 
 @jsonDefaults case class FamilyHistory(
-  Relation: Relation = Relation.apply(),
+  Relation: Relation,
   Problems: Seq[FamilyHistoryProblem] = Seq.empty
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
@@ -39,7 +39,7 @@ object MediaAvailability extends Enumeration with HasDefaultReads {
   Provider: Option[Provider] = None,
   Authenticated: Option[String] = None,
   Authenticator: Option[Provider] = None,
-  Availability: MediaAvailability.Value,
+  Availability: MediaAvailability.Value = MediaAvailability.defaultValue,
   Notifications: Seq[Provider] = Seq.empty
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/MedicalEquipment.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/MedicalEquipment.scala
@@ -20,7 +20,7 @@ import com.github.vitalsoftware.macros._
   Status: String,
   StartDate: Option[DateTime] = None,
   Quantity: Option[String] = None, // Todo Int?
-  Product: BasicCode
+  Product: BasicCode = BasicCode()
 )
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
@@ -56,7 +56,7 @@ trait Medication extends DateRange {
   StartDate: DateTime,
   EndDate: Option[DateTime] = None,
   Frequency: Option[TimePeriod] = None,
-  Product: BasicCode
+  Product: BasicCode = BasicCode()
 ) extends Medication
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -51,7 +51,7 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
   DocumentID: String,
   ServiceDateTime: Option[DateTime] = None,
   DocumentationDateTime: Option[DateTime] = None,
-  Provider: Provider = Provider.apply(),
+  Provider: Provider,
   Status: Option[String] = None,
   Authenticator: Option[Provider] = None,
   Notifications: Seq[Provider] = Seq.empty

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -43,7 +43,7 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
 )
 
 @jsonDefaults case class Note(
-  ContentType: NoteContentTypes.Value,
+  ContentType: NoteContentTypes.Value = NoteContentTypes.defaultValue,
   FileName: Option[String] = None,
   FileContents: Option[String] = None,
   Components: Seq[NoteComponent] = Seq.empty,
@@ -51,7 +51,7 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
   DocumentID: String,
   ServiceDateTime: Option[DateTime] = None,
   DocumentationDateTime: Option[DateTime] = None,
-  Provider: Provider,
+  Provider: Provider = Provider(),
   Status: Option[String] = None,
   Authenticator: Option[Provider] = None,
   Notifications: Seq[Provider] = Seq.empty

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -51,7 +51,7 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
   DocumentID: String,
   ServiceDateTime: Option[DateTime] = None,
   DocumentationDateTime: Option[DateTime] = None,
-  Provider: Provider = Provider(),
+  Provider: Provider = Provider.apply(),
   Status: Option[String] = None,
   Authenticator: Option[Provider] = None,
   Notifications: Seq[Provider] = Seq.empty

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -74,7 +74,7 @@ object OrderPriorityTypes extends Enumeration with HasDefaultReads {
   NPI: Option[String] = None,
   FirstName: Option[String] = None,
   LastName: Option[String] = None,
-  Type: Option[String],
+  Type: Option[String] = None,
   Credentials: Seq[String] = Seq.empty,
   Address: Option[Address] = None,
   Location: Option[CareLocation] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.HasDefault
 import play.api.libs.json.Reads.DefaultJodaDateReads
 import play.api.libs.json._
 
@@ -23,7 +24,7 @@ import scala.collection.Seq
   IDType: String
 )
 
-object SexType extends Enumeration {
+object SexType extends Enumeration with HasDefault {
   val Male, Female, Unknown, Other = Value
 
   val strictReads: Reads[SexType.Value] = Reads.enumNameReads(SexType)
@@ -40,6 +41,8 @@ object SexType extends Enumeration {
     }
   }
   implicit lazy val jsonFormat: Format[SexType.Value] = Format(fuzzyReads, Writes.enumNameWrites)
+
+  override def defaultValue: SexType.Value = Unknown
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
@@ -19,7 +19,7 @@ import com.github.vitalsoftware.macros._
   StartDate: DateTime,
   EndDate: Option[DateTime] = None,
   Frequency: Option[TimePeriod] = None,
-  Product: BasicCode
+  Product: BasicCode = BasicCode()
 ) extends Medication with Status with DateRange
 
 /**
@@ -47,5 +47,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class PlanOfCareMessage(
   PlanOfCareText: Option[String] = None,
-  PlanOfCare: PlanOfCare
+  PlanOfCare: PlanOfCare = PlanOfCare()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
@@ -47,5 +47,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class PlanOfCareMessage(
   PlanOfCareText: Option[String] = None,
-  PlanOfCare: PlanOfCare = PlanOfCare.apply()
+  PlanOfCare: PlanOfCare
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
@@ -47,5 +47,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class PlanOfCareMessage(
   PlanOfCareText: Option[String] = None,
-  PlanOfCare: PlanOfCare = PlanOfCare()
+  PlanOfCare: PlanOfCare = PlanOfCare.apply()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
@@ -24,7 +24,7 @@ import com.github.vitalsoftware.macros._
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
-  Category: BasicCode,
+  Category: BasicCode = BasicCode(),
   //HealthStatus: Option[BasicCode] = None, // TODO Seems to come back as HealthStatus: { null, null, null, null } which violates the constraints of BasicCode
   Status: Option[BasicCode] = None
 ) extends Code

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
@@ -26,5 +26,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class ProceduresMessage(
   ProceduresText: Option[String] = None,
-  Procedures: Procedures
+  Procedures: Procedures = Procedures()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
@@ -26,5 +26,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class ProceduresMessage(
   ProceduresText: Option[String] = None,
-  Procedures: Procedures = Procedures.apply()
+  Procedures: Procedures
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
@@ -26,5 +26,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class ProceduresMessage(
   ProceduresText: Option[String] = None,
-  Procedures: Procedures = Procedures()
+  Procedures: Procedures = Procedures.apply()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
@@ -18,10 +18,10 @@ import com.github.vitalsoftware.macros._
  * @param Address Provider's address
  */
 @jsonDefaults case class Provider(
-  ID: Option[String],
-  IDType: Option[String],
-  FirstName: Option[String],
-  LastName: Option[String],
+  ID: Option[String] = None,
+  IDType: Option[String] = None,
+  FirstName: Option[String] = None,
+  LastName: Option[String] = None,
   Type: Option[String] = None,
   Credentials: Seq[String] = Seq.empty,
   Address: Option[Address] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -69,7 +69,7 @@ import play.api.libs.json.{ Format, Reads, Writes }
   Description: Option[String] = None,
   Specimen: Option[Specimen] = None,
   Value: String,
-  ValueType: ValueTypes.Value,
+  ValueType: ValueTypes.Value = ValueTypes.defaultValue,
   FileType: Option[String] = None,
   Units: Option[String] = None,
   Notes: Seq[String] = Seq.empty,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
@@ -62,5 +62,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class SocialHistoryMessage(
   SocialHistoryText: Option[String] = None,
-  SocialHistory: SocialHistory
+  SocialHistory: SocialHistory = SocialHistory()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
@@ -62,5 +62,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class SocialHistoryMessage(
   SocialHistoryText: Option[String] = None,
-  SocialHistory: SocialHistory = SocialHistory()
+  SocialHistory: SocialHistory = SocialHistory.apply()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
@@ -62,5 +62,5 @@ import com.github.vitalsoftware.macros._
  */
 @jsonDefaults case class SocialHistoryMessage(
   SocialHistoryText: Option[String] = None,
-  SocialHistory: SocialHistory = SocialHistory.apply()
+  SocialHistory: SocialHistory
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0-SNAPSHOT"
+version in ThisBuild := "1.3.0-SNAPSHOT"


### PR DESCRIPTION
- Upgrade `json-annotations` version that does robust json parsing and fallback to defaults when parsing fails.

- Assign defaults to data models without changing type signature.