### PR TITLE
Recover from Json parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changes signature of `webhook` to return both potential error and results. `(Option[JsError], Option[AnyRef])`
+
 ## [1.3.0] - 2018-08-10
 
 - With the upgrade of `json-annotations` library. We will now assign default values to message fields

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.6",
   "com.typesafe.akka" %% "akka-http" % "10.0.9",
   //"ai.x" %% "play-json-extensions" % "0.8.0",
-  "com.github.vital-software" %% "json-annotation" % "0.5.0",
+  "com.github.vital-software" %% "json-annotation" % "0.6.0",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",
   "org.specs2" %% "specs2-core" % "4.2.0" % Test
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -262,10 +262,11 @@ object RedoxClient {
             pruned.transform(transforms)
               .flatMap(_.validate(reads))
               .asEither
+              .left.map(_ => errors)
               .right.map(res => (Some(JsError(errors)), Some(res)))
           }
       }
-      .left.map(err => (Some(JsError(err)), None))
+      .left.map(errors => (Some(JsError(errors)), None))
       .merge
   }
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientTest.scala
@@ -1,0 +1,64 @@
+package com.github.vitalsoftware.scalaredox.client
+
+import com.github.vitalsoftware.macros.{ json, jsonDefaults }
+import org.specs2.mutable.Specification
+import play.api.libs.json._
+
+@json case class Person(name: String, age: Int, gender: Option[String])
+@jsonDefaults case class Person2(name: String, age: Int = 7, gender: Option[String] = None)
+@jsonDefaults case class Test(f1: Int = 1, f2: String = "2", f3: Boolean = true, f4: Option[Test])
+
+class RedoxClientTest extends Specification {
+
+  "robustParsing" should {
+    "make invalid option values None" in {
+      val json = Json.obj(
+        "name" -> "Victor Hugo",
+        "age" -> 46,
+        "gender" -> true
+      )
+
+      val (errors, result) = RedoxClient.robustParsing(Person.jsonAnnotationFormat.reads, json)
+      result must beSome(Person("Victor Hugo", 46, None))
+      errors must beSome[JsError]
+
+      val (errors2, result2) = RedoxClient.robustParsing(Person2.jsonAnnotationFormat.reads, json)
+      result2 must beSome(Person2("Victor Hugo", 46))
+      errors2 must beSome[JsError]
+    }
+
+    "make invalid values with defaults fallback to the default" in {
+      val json = Json.obj(
+        "name" -> "Victor Hugo",
+        "age" -> "non age"
+      )
+
+      val (errors, result) = RedoxClient.robustParsing(Person2.jsonAnnotationFormat.reads, json)
+      result must beSome(Person2("Victor Hugo", 7))
+      errors must beSome[JsError]
+    }
+
+    "throw on invalid values which are not optional or default" in {
+      val json = Json.obj(
+        "name" -> "Victor Hugo",
+        "age" -> "non age"
+      )
+
+      val (errors, result) = RedoxClient.robustParsing(Person.jsonAnnotationFormat.reads, json)
+
+      result must beNone
+      errors must beSome[JsError]
+      errors.get.errors.head._1.path.head.asInstanceOf[KeyPathNode].key mustEqual ("age")
+      errors.get.errors.head._2.head.message must contain("error.expected.jsnumber")
+    }
+
+    "multiple defaults must get replaced" in {
+      val json = Json.obj("f1" -> "str", "f2" -> false, "f3" -> 3, "f4" -> "not test")
+      val (errors, result) = RedoxClient.robustParsing(Test.jsonAnnotationFormat, json)
+
+      result must beSome(Test(f4 = None))
+      errors must beSome[JsError]
+      errors.get.errors.map(_._1.toJsonString) must contain(allOf("obj.f1", "obj.f2", "obj.f3", "obj.f4"))
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.1-SNAPSHOT"
+version in ThisBuild := "1.4.0-SNAPSHOT"


### PR DESCRIPTION
Connected to: vital-software/api#1135

Due to robust parsing, we can return a result while still having errors. We need to pass both potential result and the error back to the consumer. This changes the return type signature of `RedoxClient.Webhook` to return both error and result as a tuple of options. `(Option[JsError], Option[AnyRef])`
