### PR TITLE
Prune deep json paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix bug where robust parsing fails to recover from deep errors
+
 ## [1.4.0] - 2018-08-13
 
 - Changes signature of `webhook` to return both potential error and results. `(Option[JsError], Option[AnyRef])`

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -257,7 +257,6 @@ object RedoxClient {
     .fold(
       invalid = { errors =>
         val transforms = errors.map(_._1)
-          .filter(_.path.size == 1)
           .map(_.json.prune)
           .reduce(_ andThen _)
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientTest.scala
@@ -60,5 +60,14 @@ class RedoxClientTest extends Specification {
       errors must beSome[JsError]
       errors.get.errors.map(_._1.toJsonString) must contain(allOf("obj.f1", "obj.f2", "obj.f3", "obj.f4"))
     }
+
+    "Replace deep nested values" in {
+      val json = Json.obj("f4" -> Json.obj("f3" -> "not boolean"))
+      val (errors, result) = RedoxClient.robustParsing(Test.jsonAnnotationFormat, json)
+
+      result must beSome(Test(f4 = Some(Test(f4 = None))))
+      errors must beSome[JsError]
+      errors.get.errors.map(_._1.toJsonString) must contain(allOf("obj.f4.f3"))
+    }
   }
 }


### PR DESCRIPTION
The non-macro version of robust parsing doesn't work recursively. Therefore we need to recover and prune deep json paths.