### PR TITLE
Robust primitive parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added robust parsing for primitive types.
+
 ## [1.4.2] - 2018-08-19
 
 - Fix robust parsing issue with json arrays.

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/AdvanceDirective.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/AdvanceDirective.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -31,7 +32,11 @@ import com.github.vitalsoftware.macros._
   Custodians: Seq[BasicPerson] = Seq.empty
 ) extends Code with DateRange
 
+object AdvanceDirective extends RobustPrimitives
+
 @jsonDefaults case class AdvanceDirectiveMessage(
   AdvanceDirectivesText: Option[String] = None,
   advanceDirectives: Seq[AdvanceDirective] = Seq.empty
 )
+
+object AdvanceDirectiveMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Allergy.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Allergy.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -30,6 +31,8 @@ import com.github.vitalsoftware.macros._
   Comment: Option[String] = None
 )
 
+object Allergy extends RobustPrimitives
+
 /**
  * describes any medication allergies, food allergies, or reactions to other substances
  * (such as latex, iodine, tape adhesives). At a minimum, it should list currently active
@@ -39,3 +42,5 @@ import com.github.vitalsoftware.macros._
   AllergyText: Option[String] = None,
   Allergies: Seq[Allergy] = Seq.empty
 )
+
+object AllergiesMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/ClinicalSummary.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/ClinicalSummary.scala
@@ -1,6 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 //import ai.x.play.json.Jsonx
 
 /**
@@ -15,6 +16,8 @@ import com.github.vitalsoftware.macros._
   Meta: Meta,
   Patient: Patient
 ) extends HasPatient
+
+object PatientQuery extends RobustPrimitives
 
 /**
  * A Clinical Summary represents a snapshot of the patient's chart at a moment in time. It is structured in sections,
@@ -41,6 +44,8 @@ import com.github.vitalsoftware.macros._
   SocialHistory: Option[SocialHistory] = None,
   VitalSigns: Seq[VitalSigns] = Seq.empty
 ) extends ClinicalSummaryLike
+
+object ClinicalSummary extends RobustPrimitives
 
 /**
  * TODO: Running into Function22 and Tuple22 limits here...
@@ -105,6 +110,8 @@ import com.github.vitalsoftware.macros._
   VitalSigns: Seq[VitalSigns] = Seq.empty
 ) extends ClinicalSummaryLike
 
+object Visit extends RobustPrimitives
+
 // Common structure between Visit and ClinicalSummary
 trait ClinicalSummaryLike extends MetaLike with HasPatient {
   def Meta: Meta
@@ -123,4 +130,4 @@ trait ClinicalSummaryLike extends MetaLike with HasPatient {
 object Visit {
   implicit lazy val jsonFormat = Jsonx.formatCaseClass[Visit]
 }
-*/ 
+*/

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -3,7 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
-import com.github.vitalsoftware.util.HasDefaultReads
+import com.github.vitalsoftware.util.{ HasDefaultReads, RobustPrimitives }
 import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
@@ -43,6 +43,8 @@ trait Code {
   Name: Option[String] = None
 ) extends Code
 
+object BasicCode extends RobustPrimitives
+
 @jsonDefaults case class CodeWithText(
   Code: Option[String] = None,
   CodeSystem: Option[String] = None,
@@ -50,6 +52,8 @@ trait Code {
   Name: Option[String] = None,
   Text: Option[String] = None
 ) extends Code
+
+object CodeWithText extends RobustPrimitives
 
 @jsonDefaults case class CodeWithStatus(
   Code: Option[String] = None,
@@ -60,6 +64,8 @@ trait Code {
   DateTime: Option[DateTime] = None
 ) extends Code with Status
 
+object CodeWithStatus extends RobustPrimitives
+
 // Alternative to 'BasicCode' used inconsistently in some data models
 @jsonDefaults case class CodeSet(
   Code: Option[String] = None,
@@ -69,6 +75,8 @@ trait Code {
   Description: Option[String] = None
 )
 
+object CodeSet extends RobustPrimitives
+
 @jsonDefaults case class Address(
   StreetAddress: Option[String] = None,
   City: Option[String] = None,
@@ -77,6 +85,8 @@ trait Code {
   County: Option[String] = None,
   Country: Option[String] = None
 )
+
+object Address extends RobustPrimitives
 
 /**
  * Location of provider or care given.
@@ -89,6 +99,8 @@ trait Code {
   Type: BasicCode = BasicCode(),
   Name: Option[String] = None
 )
+
+object Location extends RobustPrimitives
 
 /**
  * Location of provider or care given.
@@ -105,12 +117,16 @@ trait Code {
   Bed: Option[String] = None
 )
 
+object CareLocation extends RobustPrimitives
+
 // In E. 164 Format. (e.g. +16085551234)
 @jsonDefaults case class PhoneNumber(
   Home: Option[String] = None,
   Mobile: Option[String] = None,
   Office: Option[String] = None
 )
+
+object PhoneNumber extends RobustPrimitives
 
 /**
  * Reference range for the result.
@@ -126,6 +142,8 @@ trait Code {
   High: Option[Double] = None,
   Text: Option[String] = None
 )
+
+object ReferenceRange extends RobustPrimitives
 
 object ValueTypes extends Enumeration with HasDefaultReads {
   val Numeric, String, Date, Time, DateTime = Value
@@ -159,3 +177,5 @@ object ValueTypes extends Enumeration with HasDefaultReads {
   Interpretation: Option[String] = None, // Used by Result
   Observer: Option[Provider] = None
 ) extends Code with Status with DateStamped
+
+object Observation extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Document.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Document.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -28,6 +29,8 @@ import com.github.vitalsoftware.macros._
   Type: String
 ) extends HasVisitInfo
 
+object Document extends RobustPrimitives
+
 /**
  * Information about the patient and where the summary came from
  *
@@ -38,3 +41,5 @@ import com.github.vitalsoftware.macros._
   Document: Document,
   Patient: Patient
 ) extends HasPatient
+
+object Header extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Encounter.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Encounter.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -29,6 +30,8 @@ import com.github.vitalsoftware.macros._
   ReasonForVisit: Seq[BasicCode] = Seq.empty
 ) extends DateStamped
 
+object Encounter extends RobustPrimitives
+
 /**
  * This section lists the patient's past encounters at the health system and associated diagnoses.
  *
@@ -39,3 +42,5 @@ import com.github.vitalsoftware.macros._
   EncountersText: Option[String],
   Encounters: Seq[Encounter] = Seq.empty
 )
+
+object EncountersMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FamilyHistory.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.{ DateTime, LocalDate }
 import com.github.vitalsoftware.util.JsonImplicits._
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -17,6 +18,8 @@ import com.github.vitalsoftware.macros._
   DOB: Option[LocalDate] = None
 )
 
+object FamilyDemographics extends RobustPrimitives
+
 @jsonDefaults case class Relation(
   Code: Option[String] = None,
   CodeSystem: Option[String] = None,
@@ -26,6 +29,8 @@ import com.github.vitalsoftware.macros._
   IsDeceased: Option[Boolean] = None
 ) extends Code
 
+object Relation extends RobustPrimitives
+
 /**
  * @param Sex Relation gender
  * @param DOB Date of Birth of the relative. In YYYY-MM-DD format
@@ -34,6 +39,8 @@ import com.github.vitalsoftware.macros._
   Sex: SexType.Value = SexType.defaultValue,
   DOB: LocalDate
 )
+
+object RelationDemographics extends RobustPrimitives
 
 /**
  * Health problem.
@@ -53,10 +60,14 @@ import com.github.vitalsoftware.macros._
   IsCauseOfDeath: Option[Boolean] = None
 ) extends Code
 
+object FamilyHistoryProblem extends RobustPrimitives
+
 @jsonDefaults case class FamilyHistory(
   Relation: Relation,
   Problems: Seq[FamilyHistoryProblem] = Seq.empty
 )
+
+object FamilyHistory extends RobustPrimitives
 
 /**
  * This section contains entries for a patient's relatives and their health problems.
@@ -67,3 +78,5 @@ import com.github.vitalsoftware.macros._
   FamilyHistoryTest: Option[String] = None,
   FamilyHistory: Seq[FamilyHistory] = Seq.empty
 )
+
+object FamilyHistoryMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FlowSheetMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FlowSheetMessage.scala
@@ -1,6 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 6/8/18.
@@ -17,3 +18,5 @@ import com.github.vitalsoftware.macros.jsonDefaults
   Visit: Option[BasicVisitInfo] = None,
   Observations: Seq[Observation] = Nil
 ) extends MetaLike with HasPatient
+
+object FlowSheetMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Immunization.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Immunization.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -26,6 +27,8 @@ import com.github.vitalsoftware.macros._
   LotNumber: Option[String] = None
 ) extends Code
 
+object ImmunizationProduct extends RobustPrimitives
+
 /**
  * @see [UCUM Units of Measure](http://unitsofmeasure.org/ucum.html)
  *
@@ -36,6 +39,8 @@ import com.github.vitalsoftware.macros._
   Quantity: Option[String] = None,
   Units: Option[String] = None
 )
+
+object Dose extends RobustPrimitives
 
 /**
  * Immunization given.
@@ -52,6 +57,8 @@ import com.github.vitalsoftware.macros._
   Dose: Option[Dose] = None
 ) extends DateStamped
 
+object Immunization extends RobustPrimitives
+
 /**
  * This section lists the patient's current immunization status and pertinent immunization history.
  */
@@ -59,3 +66,5 @@ import com.github.vitalsoftware.macros._
   ImmunizationText: Option[String] = None,
   Immunizations: Seq[Immunization] = Seq.empty
 )
+
+object ImmunizationsMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
@@ -3,7 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.LocalDate
 import com.github.vitalsoftware.util.JsonImplicits.jodaLocalDateFormat
 import com.github.vitalsoftware.macros._
-import com.github.vitalsoftware.util.HasDefaultReads
+import com.github.vitalsoftware.util.{ HasDefaultReads, RobustPrimitives }
 import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
@@ -22,6 +22,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
   Name: Option[String] = None
 )
 
+object InsurancePlan extends RobustPrimitives
+
 /**
  *
  * @param ID ID of insurance company (payor)
@@ -37,6 +39,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
   Address: Option[Address] = None,
   PhoneNumber: Option[String] = None
 )
+
+object InsuranceCompany extends RobustPrimitives
 
 object InsuranceRelationshipTypes extends Enumeration with HasDefaultReads {
   val Self, Spouse, Other = Value
@@ -69,12 +73,16 @@ object InsuranceCoverageTypes extends Enumeration with HasDefaultReads {
   PhoneNumber: Option[PhoneNumber] = None
 )
 
+object InsuredPerson extends RobustPrimitives
+
 /** Guarantor's Employer */
 @jsonDefaults case class Employer(
   Name: Option[String] = None,
   Address: Option[Address] = None,
   PhoneNumber: Option[String] = None
 )
+
+object Employer extends RobustPrimitives
 
 /**
  * Person ultimately responsible for the bill of the appointment
@@ -93,6 +101,8 @@ object InsuranceCoverageTypes extends Enumeration with HasDefaultReads {
   Type: Option[String] = None,
   Employer: Option[Employer] = None
 )
+
+object Guarantor extends RobustPrimitives
 
 /**
  * List of insurance coverages for the patient
@@ -119,3 +129,5 @@ object InsuranceCoverageTypes extends Enumeration with HasDefaultReads {
   CoverageType: Option[InsuranceCoverageTypes.Value] = None,
   Insured: Option[InsuredPerson] = None
 )
+
+object Insurance extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
@@ -1,7 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros._
-import com.github.vitalsoftware.util.HasDefaultReads
+import com.github.vitalsoftware.util.{ HasDefaultReads, RobustPrimitives }
 import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
@@ -43,6 +43,8 @@ object MediaAvailability extends Enumeration with HasDefaultReads {
   Notifications: Seq[Provider] = Seq.empty
 )
 
+object Media extends RobustPrimitives
+
 /**
  * @param Visit Only Visit.VisitNumber A VisitNumber is highly recommended so that the document can be associated with a specific visit
  */
@@ -52,3 +54,5 @@ object MediaAvailability extends Enumeration with HasDefaultReads {
   Media: Media,
   Visit: Option[VisitInfo] = None
 ) extends MetaLike with HasVisitInfo with HasPatient
+
+object MediaMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/MedicalEquipment.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/MedicalEquipment.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -23,6 +24,8 @@ import com.github.vitalsoftware.macros._
   Product: BasicCode = BasicCode()
 )
 
+object MedicalEquipment extends RobustPrimitives
+
 /**
  * This section lists any medical equipment that the patient uses or has been prescribed.
  * @param MedicalEquipmentText Free text form of the medical equipment summary
@@ -32,3 +35,5 @@ import com.github.vitalsoftware.macros._
   MedicalEquipmentText: Option[String] = None,
   MedicalEquipment: Seq[MedicalEquipment] = Seq.empty
 )
+
+object MedicalEquipmentMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -43,6 +44,8 @@ trait Medication extends DateRange {
   Unit: Option[String] = None
 )
 
+object TimePeriod extends RobustPrimitives
+
 /**
  * @param Prescription Whether the medication is a prescription. For a prescription: true. For a patient reported med, or a med administered by a provider: false
  * @param FreeTextSig Free text instructions for the medication. Typically instructing patient on the proper means and timing for the use of the medication
@@ -59,6 +62,8 @@ trait Medication extends DateRange {
   Product: BasicCode = BasicCode()
 ) extends Medication
 
+object MedicationTaken extends RobustPrimitives
+
 /**
  * This section contains the patient's past, current, and future medications.
  *
@@ -69,3 +74,5 @@ trait Medication extends DateRange {
   MedicationsText: Option[String] = None,
   Medications: Seq[MedicationTaken] = Seq.empty
 )
+
+object MedicationsMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
@@ -28,8 +29,12 @@ object RedoxEventTypes extends Enumeration {
 // Message source or destination
 @jsonDefaults case class SourceDestination(ID: UUID, Name: Option[String] = None)
 
+object SourceDestination extends RobustPrimitives
+
 // Numeric identifier
 @jsonDefaults case class NumericIdentifier(ID: Long)
+
+object NumericIdentifier extends RobustPrimitives
 
 /**
  * Request/response header meta-data
@@ -57,3 +62,5 @@ object RedoxEventTypes extends Enumeration {
   FacilityCode: Option[String] = None,
   IsIncomplete: Option[Boolean] = None
 )
+
+object Meta extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -2,7 +2,7 @@ package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.util.JsonImplicits._
 import com.github.vitalsoftware.macros._
-import com.github.vitalsoftware.util.HasDefaultReads
+import com.github.vitalsoftware.util.{ HasDefaultReads, RobustPrimitives }
 import org.joda.time.DateTime
 import play.api.libs.json.{ Format, Reads, Writes }
 
@@ -28,6 +28,8 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
   Name: Option[String] = None
 )
 
+object NoteOrder extends RobustPrimitives
+
 /**
  *
  * @param ID The ID of the discrete note component. A report ID, or documentation field ID
@@ -41,6 +43,8 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
   Value: Option[String] = None,
   Comments: Option[String] = None
 )
+
+object NoteComponent extends RobustPrimitives
 
 @jsonDefaults case class Note(
   ContentType: NoteContentTypes.Value = NoteContentTypes.defaultValue,
@@ -57,6 +61,8 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
   Notifications: Seq[Provider] = Seq.empty
 )
 
+object Note extends RobustPrimitives
+
 /**
  * @param Visit Requires only VisitNumber + VisitDateTime
  */
@@ -67,3 +73,5 @@ object NoteContentTypes extends Enumeration with HasDefaultReads {
   Note: Note,
   Orders: Seq[NoteOrder] = Seq.empty
 ) extends MetaLike with HasPatient with HasVisitInfo
+
+object NoteMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -3,7 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import java.time.LocalDate
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.HasDefaultReads
+import com.github.vitalsoftware.util.{ HasDefaultReads, RobustPrimitives }
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import org.joda.time.DateTime
 import play.api.libs.json.{ Format, Reads, Writes }
@@ -25,6 +25,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
   BodySite: Option[String] = None,
   ID: Option[String] = None
 )
+
+object Specimen extends RobustPrimitives
 
 object OrderPriorityTypes extends Enumeration with HasDefaultReads {
   val Stat = Value("Stat")
@@ -59,6 +61,8 @@ object OrderPriorityTypes extends Enumeration with HasDefaultReads {
   Notes: Seq[String] = Seq.empty
 )
 
+object ClinicalInfo extends RobustPrimitives
+
 /** The "Producer" is typically the Lab which did the resulting. */
 @jsonDefaults case class OrderProducer(
   ID: Option[String] = None,
@@ -66,6 +70,8 @@ object OrderPriorityTypes extends Enumeration with HasDefaultReads {
   Name: Option[String] = None,
   Address: Option[Address] = None
 )
+
+object OrderProducer extends RobustPrimitives
 
 /**
  * @param NPI A National Provider Identifier or NPI is a unique 10-digit identification number issued to health care providers in the United States
@@ -86,12 +92,16 @@ object OrderPriorityTypes extends Enumeration with HasDefaultReads {
   def IDType: Option[String] = Some("NPI")
 }
 
+object OrderProvider extends RobustPrimitives
+
 /** Facility this order was placed in */
 @jsonDefaults case class OrderingFacility(
   Name: Option[String] = None,
   Address: Option[Address] = None,
   PhoneNumber: Option[String] = None
 )
+
+object OrderingFacility extends RobustPrimitives
 
 /**
  * Order messages communicate details of diagnostic tests such as labs, radiology imaging, etc.
@@ -126,6 +136,8 @@ object OrderPriorityTypes extends Enumeration with HasDefaultReads {
   ClinicalInfo: Seq[ClinicalInfo] = Seq.empty
 )
 
+object Order extends RobustPrimitives
+
 trait OrdersMessageLike extends HasPatient with HasVisitInfo {
   def Meta: Meta
   def Patient: Patient
@@ -142,9 +154,13 @@ trait OrdersMessageLike extends HasPatient with HasVisitInfo {
   def Orders = Seq(Order)
 }
 
+object OrderMessage extends RobustPrimitives
+
 @jsonDefaults case class GroupedOrdersMessage(
   Meta: Meta,
   Patient: Patient,
   Visit: Option[VisitInfo] = None,
   Orders: Seq[Order] = Seq.empty
 ) extends MetaLike with OrdersMessageLike
+
+object GroupedOrdersMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -3,7 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
-import com.github.vitalsoftware.util.HasDefault
+import com.github.vitalsoftware.util.{ HasDefault, RobustPrimitives }
 import play.api.libs.json.Reads.DefaultJodaDateReads
 import play.api.libs.json._
 
@@ -23,6 +23,8 @@ import scala.collection.Seq
   ID: String,
   IDType: String
 )
+
+object Identifier extends RobustPrimitives
 
 object SexType extends Enumeration with HasDefault {
   val Male, Female, Unknown, Other = Value
@@ -76,6 +78,8 @@ object SexType extends Enumeration with HasDefault {
   MaritalStatus: Option[String] = None
 ) extends Person
 
+object Demographics extends RobustPrimitives
+
 /**
  * @param RelationToPatient Personal relationship to the patient. e.x. Father, Spouse
  * @param Roles E.g. "Emergency contact"
@@ -89,6 +93,8 @@ object SexType extends Enumeration with HasDefault {
   RelationToPatient: Option[String] = None,
   Roles: Seq[String] = Seq.empty
 ) extends Person
+
+object Contact extends RobustPrimitives
 
 /**
  * Patient
@@ -104,6 +110,8 @@ object SexType extends Enumeration with HasDefault {
   PCP: Option[Provider] = None
 )
 
+object Patient extends RobustPrimitives
+
 /**
  * Used for both query (without the 'PotentialMatches') and holding the response to a patient search query.
  *
@@ -116,6 +124,8 @@ object SexType extends Enumeration with HasDefault {
   PotentialMatches: Seq[Patient] = Seq.empty
 ) extends MetaLike
 
+object PatientSearch extends RobustPrimitives
+
 /**
  * Meta.DataModel: "PatientAdmin",
  * Meta.EventType: {Arrival, Cancel, Discharge, NewPatient, PatientUpdate, PatientMerge, PreAdmit, Registration, Transfer, VisitMerge, VisitUpdate}
@@ -125,3 +135,5 @@ object SexType extends Enumeration with HasDefault {
   Patient: Patient,
   Visit: Option[VisitInfo] = None
 ) extends MetaLike with HasPatient with HasVisitInfo
+
+object PatientAdminMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/PlanOfCare.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -21,6 +22,8 @@ import com.github.vitalsoftware.macros._
   Frequency: Option[TimePeriod] = None,
   Product: BasicCode = BasicCode()
 ) extends Medication with Status with DateRange
+
+object MedicationPlan extends RobustPrimitives
 
 /**
  * @see PlanOfCareMessage
@@ -41,6 +44,8 @@ import com.github.vitalsoftware.macros._
   Services: Seq[CodeWithStatus] = Seq.empty
 )
 
+object PlanOfCare extends RobustPrimitives
+
 /**
  * This section contains future appointments, medications, orders, procedures, and services that a
  * patient may be scheduled for or is waiting to be scheduled for.
@@ -49,3 +54,5 @@ import com.github.vitalsoftware.macros._
   PlanOfCareText: Option[String] = None,
   PlanOfCare: PlanOfCare
 )
+
+object PlanOfCareMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -29,6 +30,8 @@ import com.github.vitalsoftware.macros._
   Status: Option[BasicCode] = None
 ) extends Code
 
+object Problem extends RobustPrimitives
+
 /**
  * This section contains the patient's past and current relevant medical problems.
  *
@@ -39,3 +42,5 @@ import com.github.vitalsoftware.macros._
   ProblemsText: Option[String] = None,
   Problems: Seq[Problem] = Seq.empty
 )
+
+object ProblemsMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
@@ -1,6 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -18,6 +19,8 @@ import com.github.vitalsoftware.macros._
   Services: Seq[CodeWithStatus] = Seq.empty
 )
 
+object Procedures extends RobustPrimitives
+
 /**
  * This section documents three types of things: diagnostic procedures, procedures that change the body, and services performed by clinical staff.
  *
@@ -28,3 +31,5 @@ import com.github.vitalsoftware.macros._
   ProceduresText: Option[String] = None,
   Procedures: Procedures
 )
+
+object ProceduresMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
@@ -1,6 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -31,6 +32,8 @@ import com.github.vitalsoftware.macros._
   Role: Option[BasicCode] = None
 ) extends ProviderLike
 
+object Provider extends RobustPrimitives
+
 trait ProviderLike {
   def ID: Option[String]
   def IDType: Option[String]
@@ -58,3 +61,5 @@ trait Person {
   EmailAddresses: Seq[String] = Seq.empty,
   Credentials: Option[String] = None
 ) extends Person
+
+object BasicPerson extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -1,7 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.HasDefaultReads
+import com.github.vitalsoftware.util.{ HasDefaultReads, RobustPrimitives }
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import org.joda.time.DateTime
 import play.api.libs.json.{ Format, Reads, Writes }
@@ -26,6 +26,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
   Observations: Seq[Observation] = Seq.empty
 ) extends Code with Status
 
+object ChartResult extends RobustPrimitives
+
 /**
  * Person who produced the order result.
  */
@@ -41,6 +43,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
   Location: Option[CareLocation] = None,
   PhoneNumber: Option[String] = None
 ) extends ProviderLike
+
+object ResultPerformer extends RobustPrimitives
 
 /**
  * Results messages communicate results of diagnostic tests such as labs, radiology imaging, etc.
@@ -80,6 +84,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
   ReferenceRange: Option[ReferenceRange] = None,
   ObservationMethod: Option[CodeSet] = None
 )
+
+object Result extends RobustPrimitives
 
 // Current overall status of the order. One of the following: "Final", "Preliminary", "In Process", "Corrected", "Canceled".
 object ResultsStatusTypes extends Enumeration with HasDefaultReads {
@@ -123,6 +129,8 @@ object ResultsStatusTypes extends Enumeration with HasDefaultReads {
   Results: Seq[Result] = Seq.empty
 )
 
+object OrderResult extends RobustPrimitives
+
 /**
  * Results messages communicate results of diagnostic tests such as labs, radiology imaging, etc.
  */
@@ -132,3 +140,5 @@ object ResultsStatusTypes extends Enumeration with HasDefaultReads {
   Orders: Seq[OrderResult] = Seq.empty,
   Visit: Option[VisitInfo] = None
 ) extends MetaLike with HasPatient with HasVisitInfo
+
+object ResultsMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/SocialHistory.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/20/17.
@@ -24,6 +25,8 @@ import com.github.vitalsoftware.macros._
   ValueText: Option[String] = None
 ) extends Code with DateRange
 
+object SocialHistoryObservation extends RobustPrimitives
+
 /**
  * @param StartDate When the pregnancy started. ISO 8601 Format
  * @param EndDate When the pregnancy ended. ISO 8601 Format
@@ -34,6 +37,8 @@ import com.github.vitalsoftware.macros._
   EndDate: Option[DateTime] = None,
   EstimatedDelivery: Option[String] = None
 ) extends DateRange
+
+object Pregnancy extends RobustPrimitives
 
 /**
  * @param Code A code indicating the status (current smoker, never smoker, snuff user, etc.). Contains all values descending from the SNOMED CT® 365980008 tobacco use and exposure - finding hierarchy
@@ -49,11 +54,15 @@ import com.github.vitalsoftware.macros._
   EndDate: Option[DateTime] = None
 ) extends Code
 
+object TobaccoUse extends RobustPrimitives
+
 @jsonDefaults case class SocialHistory(
   Observations: Seq[SocialHistoryObservation] = Seq.empty,
   Pregnancy: Seq[Pregnancy] = Seq.empty,
   TobaccoUse: Seq[TobaccoUse] = Seq.empty
 )
+
+object SocialHistory extends RobustPrimitives
 
 /**
  * This section contains information such as tobacco use, pregnancies, and generic social behavior observations.
@@ -64,3 +73,5 @@ import com.github.vitalsoftware.macros._
   SocialHistoryText: Option[String] = None,
   SocialHistory: SocialHistory
 )
+
+object SocialHistoryMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Upload.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Upload.scala
@@ -1,8 +1,11 @@
 package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * @author andrew.zurn@dexcom.com - 11/1/17.
  */
 @jsonDefaults case class Upload(URI: String)
+
+object Upload extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 
 /**
  * Created by apatzer on 3/17/17.
@@ -18,6 +19,8 @@ import com.github.vitalsoftware.macros._
   StartDateTime: DateTime,
   EndDateTime: Option[DateTime] = None
 )
+
+object VisitQueryParams extends RobustPrimitives
 
 /**
  * This query finds and returns visit summaries for a given patient at the specified health system within the specified
@@ -38,6 +41,8 @@ import com.github.vitalsoftware.macros._
   Visit: VisitQueryParams
 ) extends HasPatient
 
+object VisitQuery extends RobustPrimitives
+
 /**
  * @param Value The diagnosis as free text
  * @param DateTime When the diagnosis was recorded. ISO 8601 Format
@@ -51,9 +56,13 @@ import com.github.vitalsoftware.macros._
   Encodings: Seq[CodeSet] = Seq.empty
 )
 
+object Diagnosis extends RobustPrimitives
+
 @jsonDefaults case class Assessment(
   Diagnoses: Seq[Diagnosis] = Seq.empty
 )
+
+object Assessment extends RobustPrimitives
 
 /**
  * Information about the visit associate with models.Order and/or models.Result
@@ -94,6 +103,8 @@ import com.github.vitalsoftware.macros._
   EndDateTime: Option[DateTime] = None
 )
 
+object VisitInfo extends RobustPrimitives
+
 // Note: Presently used only by Flowsheet
 /**
  * @param Location Location of the patient.
@@ -104,3 +115,5 @@ import com.github.vitalsoftware.macros._
   Location: Option[CareLocation] = None,
   AccountNumber: Option[String] = None
 )
+
+object BasicVisitInfo extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VitalSigns.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VitalSigns.scala
@@ -3,6 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
 /**
  * Created by apatzer on 3/20/17.
  */
@@ -16,6 +17,8 @@ import com.github.vitalsoftware.macros._
   DateTime: DateTime,
   Observations: Seq[Observation] = Seq.empty
 )
+
+object VitalSigns extends RobustPrimitives
 
 object CommonVitalTypes extends Enumeration {
   val Height, Weight, Oximetry, Temperature, RespirationRate, Pulse, BPSystolic, BPDiastolic = Value
@@ -32,3 +35,5 @@ object CommonVitalTypes extends Enumeration {
   VitalSignsText: Option[String] = None,
   VitalSigns: Seq[VitalSigns] = Seq.empty
 )
+
+object VitalSignsMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/util/RobustPrimitives.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/RobustPrimitives.scala
@@ -2,9 +2,11 @@ package com.github.vitalsoftware.util
 
 import play.api.libs.json._
 
+import scala.util.Try
+
 trait RobustPrimitives {
 
-  private def alternative(partial: PartialFunction[JsValue, JsValue])(json: JsValue) = JsSuccess((partial.applyOrElse(json, (i: JsValue) => i)))
+  private def alternative(partial: PartialFunction[JsValue, JsValue])(json: JsValue) = JsSuccess((partial.applyOrElse(json, identity[JsValue])))
 
   private val alternativeStringReads: Reads[JsValue] = new Reads[JsValue] {
     override def reads(json: JsValue): JsResult[JsValue] = alternative {
@@ -15,7 +17,19 @@ trait RobustPrimitives {
 
   private val alternativeNumberReads: Reads[JsValue] = new Reads[JsValue] {
     override def reads(json: JsValue): JsResult[JsValue] = alternative {
-      case JsString(s) => JsNumber(BigDecimal(s))
+      case JsString(s) => Try(BigDecimal(s.trim)).map(JsNumber).getOrElse(JsString(s))
+    }(json)
+  }
+
+  private val alternativeBooleanReads: Reads[JsValue] = new Reads[JsValue] {
+    override def reads(json: JsValue): JsResult[JsValue] = alternative {
+      case JsString(s) => s.trim.toLowerCase match {
+        case s if s == "true" || s == "t"  => JsBoolean(true)
+        case s if s == "false" || s == "f" => JsBoolean(false)
+        case _                             => JsString(s)
+      }
+      case JsNumber(n) if n == 0 => JsBoolean(false)
+      case JsNumber(n) if n == 1 => JsBoolean(true)
     }(json)
   }
 
@@ -26,4 +40,5 @@ trait RobustPrimitives {
   implicit val RobustLongReads: Reads[Long] = alternativeNumberReads andThen Reads.LongReads
   implicit val RobustFloatReads: Reads[Float] = alternativeNumberReads andThen Reads.FloatReads
   implicit val RobustDoubleReads: Reads[Double] = alternativeNumberReads andThen Reads.DoubleReads
+  implicit val RobustBooleanReads: Reads[Boolean] = alternativeBooleanReads andThen Reads.BooleanReads
 }

--- a/src/main/scala/com/github/vitalsoftware/util/RobustPrimitives.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/RobustPrimitives.scala
@@ -1,0 +1,29 @@
+package com.github.vitalsoftware.util
+
+import play.api.libs.json._
+
+trait RobustPrimitives {
+
+  private def alternative(partial: PartialFunction[JsValue, JsValue])(json: JsValue) = JsSuccess((partial.applyOrElse(json, (i: JsValue) => i)))
+
+  private val alternativeStringReads: Reads[JsValue] = new Reads[JsValue] {
+    override def reads(json: JsValue): JsResult[JsValue] = alternative {
+      case JsNumber(n)  => JsString(n.toString)
+      case JsBoolean(b) => JsString(b.toString)
+    }(json)
+  }
+
+  private val alternativeNumberReads: Reads[JsValue] = new Reads[JsValue] {
+    override def reads(json: JsValue): JsResult[JsValue] = alternative {
+      case JsString(s) => JsNumber(BigDecimal(s))
+    }(json)
+  }
+
+  implicit val RobustStringReads: Reads[String] = alternativeStringReads andThen Reads.StringReads
+  implicit val RobustIntReads: Reads[Int] = alternativeNumberReads andThen Reads.IntReads
+  implicit val RobustShortReads: Reads[Short] = alternativeNumberReads andThen Reads.ShortReads
+  implicit val RobustByteReads: Reads[Byte] = alternativeNumberReads andThen Reads.ByteReads
+  implicit val RobustLongReads: Reads[Long] = alternativeNumberReads andThen Reads.LongReads
+  implicit val RobustFloatReads: Reads[Float] = alternativeNumberReads andThen Reads.FloatReads
+  implicit val RobustDoubleReads: Reads[Double] = alternativeNumberReads andThen Reads.DoubleReads
+}

--- a/src/main/scala/com/github/vitalsoftware/util/RobustPrimitives.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/RobustPrimitives.scala
@@ -24,9 +24,9 @@ trait RobustPrimitives {
   private val alternativeBooleanReads: Reads[JsValue] = new Reads[JsValue] {
     override def reads(json: JsValue): JsResult[JsValue] = alternative {
       case JsString(s) => s.trim.toLowerCase match {
-        case s if s == "true" || s == "t"  => JsBoolean(true)
-        case s if s == "false" || s == "f" => JsBoolean(false)
-        case _                             => JsString(s)
+        case s if s == "true" || s == "t" || s == "1"  => JsBoolean(true)
+        case s if s == "false" || s == "f" || s == "0" => JsBoolean(false)
+        case _                                         => JsString(s)
       }
       case JsNumber(n) if n == 0 => JsBoolean(false)
       case JsNumber(n) if n == 1 => JsBoolean(true)

--- a/src/test/scala/com/github/vitalsoftware/util/RobustParsingTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/RobustParsingTest.scala
@@ -150,5 +150,13 @@ class RobustParsingTest extends Specification {
       errors must beSome[JsError]
       result must beSome(PrimitiveContainer(List(1, 2, 3)))
     }
+
+    "recover from parsing type mismatches primitive types" in {
+      val json = Json.obj("f1" -> "1", "f2" -> 2, "f3" -> 1)
+
+      val (errors, result) = RobustParsing.robustParsing(Reads.of[Test], json)
+      errors must beNone
+      result must beSome(Test(1, "2", true, None))
+    }
   }
 }

--- a/src/test/scala/com/github/vitalsoftware/util/RobustParsingTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/RobustParsingTest.scala
@@ -150,13 +150,5 @@ class RobustParsingTest extends Specification {
       errors must beSome[JsError]
       result must beSome(PrimitiveContainer(List(1, 2, 3)))
     }
-
-    "recover from parsing type mismatches primitive types" in {
-      val json = Json.obj("f1" -> "1", "f2" -> 2, "f3" -> 1)
-
-      val (errors, result) = RobustParsing.robustParsing(Reads.of[Test], json)
-      errors must beNone
-      result must beSome(Test(1, "2", true, None))
-    }
   }
 }

--- a/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
@@ -18,8 +18,18 @@ class RobustPrimitivesTest extends Specification {
       Reads.of[String].reads(JsNumber(123)) mustEqual (JsSuccess("123"))
       Reads.of[String].reads(JsNumber(123.456)) mustEqual (JsSuccess("123.456"))
 
-      //      Reads.of[String].reads(Json.arr(1, 2, 3)) mustEqual (JsSuccess("123.456"))
+      val invalid = Reads.of[String].reads(Json.arr(1, 2, 3))
+      invalid must beAnInstanceOf[JsError]
+      invalid.asInstanceOf[JsError].errors.flatMap(_._2.map(_.message)) must contain("error.expected.jsstring")
     }
 
+    "read as number" in new TestScope {
+      Reads.of[Int].reads(JsString("123")) mustEqual (JsSuccess(123))
+      Reads.of[Short].reads(JsString("123")) mustEqual (JsSuccess(123.toShort))
+      Reads.of[Long].reads(JsString("123")) mustEqual (JsSuccess(123L))
+      Reads.of[Float].reads(JsString("123.456")) mustEqual (JsSuccess(123.456F))
+      Reads.of[Double].reads(JsString("123.456")) mustEqual (JsSuccess(123.456D))
+      Reads.of[Byte].reads(JsString("4")) mustEqual (JsSuccess(4.toByte))
+    }
   }
 }

--- a/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
@@ -1,0 +1,25 @@
+package com.github.vitalsoftware.util
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import play.api.libs.json._
+
+@jsonDefaults case class Primitives(f1: Int = 1, f2: String = "2", f3: Boolean = true, f4: Option[Test])
+
+class RobustPrimitivesTest extends Specification {
+
+  trait TestScope extends RobustPrimitives with Scope
+
+  "RobustPrimitives" should {
+    "read as string" in new TestScope {
+      Reads.of[String].reads(JsBoolean(true)) mustEqual (JsSuccess("true"))
+      Reads.of[String].reads(JsBoolean(false)) mustEqual (JsSuccess("false"))
+      Reads.of[String].reads(JsNumber(123)) mustEqual (JsSuccess("123"))
+      Reads.of[String].reads(JsNumber(123.456)) mustEqual (JsSuccess("123.456"))
+
+      //      Reads.of[String].reads(Json.arr(1, 2, 3)) mustEqual (JsSuccess("123.456"))
+    }
+
+  }
+}

--- a/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
@@ -5,7 +5,8 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import play.api.libs.json._
 
-@jsonDefaults case class Primitives(f1: Int = 1, f2: String = "2", f3: Boolean = true, f4: Option[Test])
+@jsonDefaults case class Primitives(f1: Int = 1, f2: String = "2", f3: Boolean = true)
+object Primitives extends RobustPrimitives
 
 class RobustPrimitivesTest extends Specification {
 
@@ -17,6 +18,7 @@ class RobustPrimitivesTest extends Specification {
       Reads.of[String].reads(JsBoolean(false)) mustEqual (JsSuccess("false"))
       Reads.of[String].reads(JsNumber(123)) mustEqual (JsSuccess("123"))
       Reads.of[String].reads(JsNumber(123.456)) mustEqual (JsSuccess("123.456"))
+      Reads.of[String].reads(JsString("test")) mustEqual (JsSuccess("test"))
 
       val invalid = Reads.of[String].reads(Json.arr(1, 2, 3))
       invalid must beAnInstanceOf[JsError]
@@ -30,6 +32,45 @@ class RobustPrimitivesTest extends Specification {
       Reads.of[Float].reads(JsString("123.456")) mustEqual (JsSuccess(123.456F))
       Reads.of[Double].reads(JsString("123.456")) mustEqual (JsSuccess(123.456D))
       Reads.of[Byte].reads(JsString("4")) mustEqual (JsSuccess(4.toByte))
+      Reads.of[Int].reads(JsNumber(123)) mustEqual (JsSuccess(123))
+
+      val invalidBoolean = Reads.of[Int].reads(JsBoolean(true))
+      invalidBoolean must beAnInstanceOf[JsError]
+      invalidBoolean.asInstanceOf[JsError].errors.flatMap(_._2.map(_.message)) must contain("error.expected.jsnumber")
+
+      val invalidString = Reads.of[Int].reads(JsString("123L"))
+      invalidString must beAnInstanceOf[JsError]
+      invalidString.asInstanceOf[JsError].errors.flatMap(_._2.map(_.message)) must contain("error.expected.jsnumber")
+    }
+
+    "read as boolean" in new TestScope {
+      Reads.of[Boolean].reads(JsString("true")) mustEqual (JsSuccess(true))
+      Reads.of[Boolean].reads(JsString("t")) mustEqual (JsSuccess(true))
+      Reads.of[Boolean].reads(JsString("1")) mustEqual (JsSuccess(true))
+      Reads.of[Boolean].reads(JsString("false")) mustEqual (JsSuccess(false))
+      Reads.of[Boolean].reads(JsString("f")) mustEqual (JsSuccess(false))
+      Reads.of[Boolean].reads(JsString("0")) mustEqual (JsSuccess(false))
+
+      val invalidString = Reads.of[Boolean].reads(JsString("2"))
+      invalidString must beAnInstanceOf[JsError]
+      invalidString.asInstanceOf[JsError].errors.flatMap(_._2.map(_.message)) must contain("error.expected.jsboolean")
+
+      val invalidInt = Reads.of[Boolean].reads(JsNumber(2))
+      invalidInt must beAnInstanceOf[JsError]
+      invalidInt.asInstanceOf[JsError].errors.flatMap(_._2.map(_.message)) must contain("error.expected.jsboolean")
+    }
+
+    "read object with primitives" in {
+      val json = Json.obj("f1" -> "123", "f2" -> 123, "f3" -> "true")
+      val result = Reads.of[Primitives].reads(json)
+      result mustEqual (JsSuccess(Primitives(123, "123", true)))
+    }
+
+    "fail on object with unparsable primitives" in {
+      val json = Json.obj("f1" -> "a", "f2" -> 123, "f3" -> "true")
+      val result = Reads.of[Primitives].reads(json)
+      result must beAnInstanceOf[JsError]
+      result.asInstanceOf[JsError].errors.flatMap(_._2.map(_.message)) must contain("error.expected.jsnumber")
     }
   }
 }

--- a/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/util/RobustPrimitivesTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import play.api.libs.json._
 
-@jsonDefaults case class Primitives(f1: Int = 1, f2: String = "2", f3: Boolean = true)
+@jsonDefaults case class Primitives(f1: Int, f2: String, f3: Boolean, f4: Option[Int])
 object Primitives extends RobustPrimitives
 
 class RobustPrimitivesTest extends Specification {
@@ -61,9 +61,9 @@ class RobustPrimitivesTest extends Specification {
     }
 
     "read object with primitives" in {
-      val json = Json.obj("f1" -> "123", "f2" -> 123, "f3" -> "true")
+      val json = Json.obj("f1" -> "123", "f2" -> 123, "f3" -> "true", "f4" -> "456")
       val result = Reads.of[Primitives].reads(json)
-      result mustEqual (JsSuccess(Primitives(123, "123", true)))
+      result mustEqual (JsSuccess(Primitives(123, "123", true, Some(456))))
     }
 
     "fail on object with unparsable primitives" in {


### PR DESCRIPTION
Resolves #59 

Adds robust reads for scalar types. so that we can recover from parsing errors like having a JsString("123") in a place we're expecting an Int.

This further adds support for converting values like "true", "t", "1" to Booleans from JsStrings.
