### PR TITLE
Handle language locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Change Language field from String to java.util.Locale
+
 ## [1.4.3] - 2018-08-23
 
 - Added robust parsing for primitive types.

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -1,5 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models
 
+import java.util.Locale
+
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
@@ -70,7 +72,7 @@ object SexType extends Enumeration with HasDefault {
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
   EmailAddresses: Seq[String] = Seq.empty,
-  Language: Option[String] = None, // TODO ISO 639-1
+  Language: Option[Locale] = None,
   Citizenship: Seq[String] = Seq.empty, // TODO ISO 3166
   Race: Option[String] = None,
   Ethnicity: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -72,7 +72,7 @@ object SexType extends Enumeration with HasDefault {
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
   EmailAddresses: Seq[String] = Seq.empty,
-  Language: Option[Locale] = None,
+  Language: Option[Locale] = Some(Locale.ENGLISH),
   Citizenship: Seq[String] = Seq.empty, // TODO ISO 3166
   Race: Option[String] = None,
   Ethnicity: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -72,7 +72,7 @@ object SexType extends Enumeration with HasDefault {
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
   EmailAddresses: Seq[String] = Seq.empty,
-  Language: Option[Locale] = Some(Locale.ENGLISH),
+  Language: Option[Locale] = None,
   Citizenship: Seq[String] = Seq.empty, // TODO ISO 3166
   Race: Option[String] = None,
   Ethnicity: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -1,11 +1,14 @@
 package com.github.vitalsoftware.util
 
+import java.util.{ Locale, MissingResourceException }
+
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormatter
 import play.api.libs.json._
 import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 
+import scala.collection.Seq
 import scala.language.implicitConversions
 import scala.language.postfixOps
 import scala.util.Try
@@ -119,6 +122,18 @@ trait JsonImplicits {
       case _           => false
     }
   }
+
+  implicit val localeImplicits: Format[Locale] = Format(
+    new Reads[Locale] {
+      override def reads(json: JsValue): JsResult[Locale] = json match {
+        case JsString(str) => Try(new Locale(str).getISO3Language).map(l => JsSuccess(Locale.forLanguageTag(l)))
+          .getOrElse(JsError(Seq(JsPath -> Seq(JsonValidationError("error.expected.locale")))))
+      }
+    },
+    new Writes[Locale] {
+      override def writes(o: Locale): JsValue = JsString(o.toString)
+    }
+  )
 }
 
 object JsonImplicits extends JsonImplicits


### PR DESCRIPTION
We were getting values like "Unknown" for Language field from redox. However our database fields for language only support VARCHAR(3) and caused errors. This handles language field as `Option[java.util.Locale]` and defaults to None if we fail to parse it.