### PR TITLE
Fix order value type and priority enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Add "Formatted Text" as a Order ValueType
+- Handle "ST" and "RT" Order priority value via a mapping
+
 ## [1.4.5] - 2018-08-24
 
 - Remove HasDefaultEnum json parsing

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -149,6 +149,7 @@ object ValueTypes extends Enumeration {
   val Numeric, String, Date, Time, DateTime = Value
   val CodedEntry = Value("Coded Entry")
   val EncapsulatedData = Value("Encapsulated Data")
+  val FormattedText = Value("Formatted Text")
 
   def defaultValue = String
   implicit lazy val jsonFormat: Format[ValueTypes.Value] = Format(Reads.enumNameReads(ValueTypes), Writes.enumNameWrites)

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -6,7 +6,7 @@ import com.github.vitalsoftware.macros.jsonDefaults
 import com.github.vitalsoftware.util.RobustPrimitives
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import org.joda.time.DateTime
-import play.api.libs.json.{ Format, Reads, Writes }
+import play.api.libs.json._
 
 /**
  * Order messages communicate details of diagnostic tests such as labs, radiology imaging, etc.
@@ -37,7 +37,15 @@ object OrderPriorityTypes extends Enumeration {
   val Other = Value("Other")
 
   def defaultValue = Other
-  implicit lazy val jsonFormat: Format[OrderPriorityTypes.Value] = Format(Reads.enumNameReads(OrderPriorityTypes), Writes.enumNameWrites)
+
+  lazy val mappings = Map(
+    "ST" -> "Stat",
+    "RT" -> "Routine"
+  )
+
+  implicit lazy val jsonFormat: Format[OrderPriorityTypes.Value] = Format(Reads {
+    case JsString(v) => JsSuccess(JsString(mappings.getOrElse(v, v)))
+  } andThen Reads.enumNameReads(OrderPriorityTypes), Writes.enumNameWrites)
 }
 
 /**


### PR DESCRIPTION
Resolves #68 

This adds a new enum value for ValueType called "FormattedText" and to handle multiple enum values for Order PriorityType, A mapping is added 

```
"ST" -> "Stat",
"RT" -> "Routine"
```