### PR TITLE
Add PatientClass enum to visit info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Make VisitInfo.Patient class an enum value
+
 ## [1.4.6] - 2018-09-04
 
 - Add "Formatted Text" as a Order ValueType

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -4,6 +4,7 @@ import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
 import com.github.vitalsoftware.util.RobustPrimitives
+import play.api.libs.json.{ Format, Reads, Writes }
 
 /**
  * Created by apatzer on 3/17/17.
@@ -65,6 +66,14 @@ object Diagnosis extends RobustPrimitives
 object Assessment extends RobustPrimitives
 
 /**
+ * Patient class is used in many EHRs to determine where to put the patient.
+ */
+object PatientClassType extends Enumeration {
+  val Inpatient, Outpatient, Emergency = Value
+  implicit lazy val jsonFormat: Format[PatientClassType.Value] = Format(Reads.enumNameReads(PatientClassType), Writes.enumNameWrites)
+}
+
+/**
  * Information about the visit associate with models.Order and/or models.Result
  *
  * @param Location Location of the appointment
@@ -81,7 +90,7 @@ object Assessment extends RobustPrimitives
   VisitDateTime: Option[DateTime] = None,
   Duration: Option[Double] = None,
   Reason: Option[String] = None,
-  PatientClass: Option[String] = None,
+  PatientClass: Option[PatientClassType.Value] = None,
   Location: Option[CareLocation] = None,
   PreviousLocation: Option[CareLocation] = None,
   AttendingProvider: Option[Provider] = None,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.7-SNAPSHOT"
+version in ThisBuild := "1.5.0"


### PR DESCRIPTION
Connected to https://github.com/vital-software/api/issues/1364

PatientClass is important to identify the stage in the visit the patient is currently at. Since its a Required, Reliable field we can expect redox to send a set of values for this filed. Therefore better suited as an enum.

Redox documentation:
**Visit.PatientClass** `Reliable`, `Required`

Patient class is used in many EHRs to determine where to put the patient.
Examples: Inpatient, Outpatient, Emergency