### PR TITLE
Add cancelled event type to meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add CancelledEvent field to Meta
+
 ## [1.5.0] - 2018-09-18
 
 - Make VisitInfo.Patient class an enum value

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -49,6 +49,7 @@ object NumericIdentifier extends RobustPrimitives
  * @param Transmission Record in Redox that corresponds to the communication sent from Redox to your destination. Included in messages from Redox
  * @param FacilityCode Code for the facility related to the message. Only use this field if a health system indicates you should. The code is specific to the health system's EHR and might not be unique across health systems. In general, the facility fields within the data models (e.g. OrderingFacility) are more reliable and informative.
  * @param IsIncomplete Indicates that a limit was reached, and not all data was returned. If true, the sender may want to restrict the parameters of the request in order to match fewer results.
+ * @param CanceledEvent Type of event being canceled. E.g. Arrival, Discharge, PreAdmit
  */
 @jsonDefaults case class Meta(
   DataModel: DataModelTypes.Value,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -60,7 +60,8 @@ object NumericIdentifier extends RobustPrimitives
   Message: Option[NumericIdentifier] = None,
   Transmission: Option[NumericIdentifier] = None,
   FacilityCode: Option[String] = None,
-  IsIncomplete: Option[Boolean] = None
+  IsIncomplete: Option[Boolean] = None,
+  CanceledEvent: Option[RedoxEventTypes.Value] = None
 )
 
 object Meta extends RobustPrimitives


### PR DESCRIPTION
Add `CancelledEvent` to Meta. This indicates the Type of event being canceled.
E.g. Arrival, Discharge, PreAdmit
