### PR TITLE
Fix Locale validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+- Fixes Locale validation errors by introducing a strict Language type.
+
+#### Breaking
+`Pateint.Demographics.Language` is changed from java.util.Local to `Language`
+
+
 ## [1.5.1] - 2018-09-18
 
 - Add CanceledEvent field to Meta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixes Locale validation errors by introducing a strict Language type.
 
 #### Breaking
-`Pateint.Demographics.Language` is changed from java.util.Local to `Language`
+`Patient.Demographics.Language` is changed from java.util.Local to `Language`
 
 
 ## [1.5.1] - 2018-09-18

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -186,8 +186,8 @@ object ValueTypes extends Enumeration {
 object Observation extends RobustPrimitives
 
 /**
- * This wraps java.util.Locale for consisted serialisation form lanuage to an ISO standard language locale. The java
- * implementation doesn't grantee the validation of the input and the json formats gets masked by play-json's
+ * This wraps java.util.Locale for consistent serialisation form language to an ISO standard language locale. The java
+ * implementation doesn't guarantee the validation of the input and the json formats gets masked by play-json's
  * implementation that doesn't handle validation.
  */
 case class Language(underlying: Locale) {

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -1,7 +1,5 @@
 package com.github.vitalsoftware.scalaredox.models
 
-import java.util.Locale
-
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
@@ -72,7 +70,7 @@ object SexType extends Enumeration {
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
   EmailAddresses: Seq[String] = Seq.empty,
-  Language: Option[Locale] = None,
+  Language: Option[Language] = None,
   Citizenship: Seq[String] = Seq.empty, // TODO ISO 3166
   Race: Option[String] = None,
   Ethnicity: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonOps.scala
@@ -122,18 +122,6 @@ trait JsonImplicits {
       case _           => false
     }
   }
-
-  implicit val localeImplicits: Format[Locale] = Format(
-    new Reads[Locale] {
-      override def reads(json: JsValue): JsResult[Locale] = json match {
-        case JsString(str) if Try(new Locale(str).getISO3Language).isSuccess => JsSuccess(Locale.forLanguageTag(str))
-        case _ => JsError(Seq(JsPath -> Seq(JsonValidationError("error.expected.locale"))))
-      }
-    },
-    new Writes[Locale] {
-      override def writes(o: Locale): JsValue = JsString(o.toString)
-    }
-  )
 }
 
 object JsonImplicits extends JsonImplicits

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/models/CommonTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/models/CommonTest.scala
@@ -1,0 +1,28 @@
+package com.github.vitalsoftware.scalaredox.models
+
+import org.specs2.matcher.Matcher
+import org.specs2.mutable.Specification
+import play.api.libs.json.{ JsError, JsResult, JsString, JsSuccess }
+
+class CommonTest extends Specification {
+
+  def beLanguageOf(l: String): Matcher[JsResult[Language]] = (s: JsResult[Language]) => {
+    s must beAnInstanceOf[JsSuccess[Language]]
+    s.get.toString mustEqual (l)
+  }
+
+  "Language" should {
+    "read valid language locale" in {
+      JsString("en").validate[Language] must beLanguageOf("eng")
+
+      JsString("eng").validate[Language] must beLanguageOf("eng")
+
+      JsString("fr").validate[Language] must beLanguageOf("fra")
+    }
+
+    "read invalid language locale" in {
+      val unknown = JsString("unknown").validate[Language]
+      unknown must beAnInstanceOf[JsError]
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.2-SNAPSHOT"
+version in ThisBuild := "1.6.0-SNAPSHOT"


### PR DESCRIPTION
Connected to https://github.com/vital-software/api/issues/1336

https://github.com/vital-software/api/issues/1336 Is cased by our implicit `json.Formats[locale]` with validation getting masked form default `Locale` formats in play-json. To avoid this and to make the language type more specific, A `Language` type that wraps `java.util.Locale` is introduced.

This will ensure Language specific validations are done at the time we parse redox requests.