### PR TITLE
Make jsonFormats implicits in Enumerations transient

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -156,7 +156,7 @@ object ValueTypes extends Enumeration {
   val FormattedText = Value("Formatted Text")
 
   def defaultValue = String
-  implicit lazy val jsonFormat: Format[ValueTypes.Value] = Format(Reads.enumNameReads(ValueTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[ValueTypes.Value] = Format(Reads.enumNameReads(ValueTypes), Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Insurance.scala
@@ -46,21 +46,21 @@ object InsuranceRelationshipTypes extends Enumeration {
   val Self, Spouse, Other = Value
 
   def defaultValue = Other
-  implicit lazy val jsonFormat: Format[InsuranceRelationshipTypes.Value] = Format(Reads.enumNameReads(InsuranceRelationshipTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[InsuranceRelationshipTypes.Value] = Format(Reads.enumNameReads(InsuranceRelationshipTypes), Writes.enumNameWrites)
 }
 
 object InsuranceAgreementTypes extends Enumeration {
   val Standard, Unified, Maternity, Other = Value
 
   def defaultValue = Other
-  implicit lazy val jsonFormat: Format[InsuranceAgreementTypes.Value] = Format(Reads.enumNameReads(InsuranceAgreementTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[InsuranceAgreementTypes.Value] = Format(Reads.enumNameReads(InsuranceAgreementTypes), Writes.enumNameWrites)
 }
 
 object InsuranceCoverageTypes extends Enumeration {
   val Patient, Clinic, Insurance, Other = Value
 
   def defaultValue = Other
-  implicit lazy val jsonFormat: Format[InsuranceCoverageTypes.Value] = Format(Reads.enumNameReads(InsuranceCoverageTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[InsuranceCoverageTypes.Value] = Format(Reads.enumNameReads(InsuranceCoverageTypes), Writes.enumNameWrites)
 }
 
 /** Individual who has the agreement with the insurance company for the related policy */

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Media.scala
@@ -14,7 +14,7 @@ object MediaAvailability extends Enumeration {
   val Available, Unavailable = Value
 
   def defaultValue = Unavailable
-  implicit lazy val jsonFormat: Format[MediaAvailability.Value] = Format(Reads.enumNameReads(MediaAvailability), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[MediaAvailability.Value] = Format(Reads.enumNameReads(MediaAvailability), Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -16,14 +16,14 @@ object DataModelTypes extends Enumeration {
   val ClinicalSummary = Value("Clinical Summary")
   val Claim, Device, Financial, Flowsheet, Inventory, Media, Notes, Order, PatientAdmin, PatientSearch, Referral, Results, Scheduling, SurgicalScheduling, Vaccination = Value
 
-  implicit lazy val jsonFormat: Format[DataModelTypes.Value] = Format(Reads.enumNameReads(DataModelTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[DataModelTypes.Value] = Format(Reads.enumNameReads(DataModelTypes), Writes.enumNameWrites)
 }
 
 object RedoxEventTypes extends Enumeration {
   val QueryResponse = Value("Query Response")
   val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge, GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery, PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace, Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse, VisitPush, VisitUpdate = Value
 
-  implicit lazy val jsonFormat: Format[RedoxEventTypes.Value] = Format(Reads.enumNameReads(RedoxEventTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[RedoxEventTypes.Value] = Format(Reads.enumNameReads(RedoxEventTypes), Writes.enumNameWrites)
 }
 
 // Message source or destination

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Note.scala
@@ -16,7 +16,7 @@ object NoteContentTypes extends Enumeration {
   val Base64 = Value("Base64 Encoded")
 
   def defaultValue = PlainText
-  implicit lazy val jsonFormat: Format[NoteContentTypes.Value] = Format(Reads.enumNameReads(NoteContentTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[NoteContentTypes.Value] = Format(Reads.enumNameReads(NoteContentTypes), Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -43,7 +43,7 @@ object OrderPriorityTypes extends Enumeration {
     "RT" -> "Routine"
   )
 
-  implicit lazy val jsonFormat: Format[OrderPriorityTypes.Value] = Format(Reads {
+  @transient implicit lazy val jsonFormat: Format[OrderPriorityTypes.Value] = Format(Reads {
     case JsString(v) => JsSuccess(JsString(mappings.getOrElse(v, v)))
   } andThen Reads.enumNameReads(OrderPriorityTypes), Writes.enumNameWrites)
 }

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -93,7 +93,7 @@ object ResultsStatusTypes extends Enumeration {
   val InProcess = Value("In Process")
 
   def defaultValue = Other
-  implicit lazy val jsonFormat: Format[ResultsStatusTypes.Value] = Format(Reads.enumNameReads(ResultsStatusTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[ResultsStatusTypes.Value] = Format(Reads.enumNameReads(ResultsStatusTypes), Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -70,7 +70,7 @@ object Assessment extends RobustPrimitives
  */
 object PatientClassType extends Enumeration {
   val Inpatient, Outpatient, Emergency = Value
-  implicit lazy val jsonFormat: Format[PatientClassType.Value] = Format(Reads.enumNameReads(PatientClassType), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[PatientClassType.Value] = Format(Reads.enumNameReads(PatientClassType), Writes.enumNameWrites)
 }
 
 /**

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VitalSigns.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VitalSigns.scala
@@ -23,7 +23,7 @@ object VitalSigns extends RobustPrimitives
 
 object CommonVitalTypes extends Enumeration {
   val Height, Weight, Oximetry, Temperature, RespirationRate, Pulse, BPSystolic, BPDiastolic = Value
-  implicit lazy val jsonFormat: Format[CommonVitalTypes.Value] = Format(Reads.enumNameReads(CommonVitalTypes), Writes.enumNameWrites)
+  @transient implicit lazy val jsonFormat: Format[CommonVitalTypes.Value] = Format(Reads.enumNameReads(CommonVitalTypes), Writes.enumNameWrites)
 }
 
 /**


### PR DESCRIPTION
Connected to vital-software/api#1492

This makes jsonFormat implicits @transient to enable all Enumeration instances JavaSerializable.