### PR TITLE
Fix sonatype release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Removed
 
-- Stopped 2.11 release as there are multiple incompatibilities.
+- Remove cross compile code for 2.11 release as there are multiple incompatibilities.
 
 ## [1.6.2] - 2018-10-18
 
@@ -53,7 +53,13 @@
 
 ## [1.4.0] - 2018-08-13
 
+### Changed
+
 - Changes signature of `webhook` to return both potential error and results. `(Option[JsError], Option[AnyRef])`
+
+### Removed
+
+- Removed support for scala 2.11 (Backdated)
 
 ## [1.3.0] - 2018-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+
+### Removed
+
 - Stopped 2.11 release as there are multiple incompatibilities.
 
 ## [1.6.2] - 2018-10-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Stopped 2.11 release as there are multiple incompatibilities.
 
 ## [1.6.2] - 2018-10-18
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,6 @@ name := "scala-redox"
 
 scalaVersion := "2.12.6"
 
-crossScalaVersions := Seq("2.11.12", "2.12.6")
-
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("snapshots"),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7"
+version in ThisBuild := "2.0.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6.3-SNAPSHOT"
+version in ThisBuild := "1.7"


### PR DESCRIPTION
Resolves #65 #67

Deprecates the cross build for 2.11 to enable sonatype release.