### PR TITLE
Add test coverage support - resolves #25

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,17 @@ steps:
       artifacts#v1.0.0:
         upload: "target/test-reports/*.xml"
 
+  - wait: ~
+    continue_on_failure: true
+
+  - name: ":scala: Report on compile problems"
+    command: .buildkite/report-compile-problems
+
+  - name: ":junit: Process artifacts"
+    plugins:
+      junit-annotate#v1.4.1:
+        artifacts: target/test-reports/*.xml
+
   - wait
 
   - block: ":rocket: Release"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,9 @@ env:
   BASE_TAG: "scala-redox-${BUILDKITE_COMMIT}"
 
 steps:
+  - name: ":git: Store Git information"
+    command: .buildkite/store-git-info
+
   - name: ":docker: :quay: Build and push base"
     agents:
       queue: docker-build
@@ -20,6 +23,8 @@ steps:
     command: .buildkite/run-tests-and-coverage
     timeout_in_minutes: 8
     plugins:
+      vital-software/metadata-env#v0.0.1:
+        get: [GIT_COMMITTED_AT]
       vital-software/docker-compose#vital-v1.8:
         config:
           - docker-compose.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,40 @@
+env:
+  BASE_TAG: "scala-redox-${BUILDKITE_COMMIT}"
+
 steps:
-  - label: ":docker: :sbt: Run tests"
-    command:
-      - docker build --tag scala-redox:${BUILDKITE_COMMIT} -f .buildkite/Dockerfile .
-      - docker run -e REDOX_API_SECRET -e REDOX_API_KEY scala-redox:${BUILDKITE_COMMIT} sbt test
+  - name: ":docker: :quay: Build and push base"
+    agents:
+      queue: docker-build
+    plugins:
+      vital-software/docker-compose#vital-v1.8:
+        config:
+          - docker-compose.yml
+          - docker-compose.buildkite.yml
+        build: scala-redox-base
+        image_repository: quay.io/vital/scala-redox
+        image-name: ${BASE_TAG}
 
   - wait
 
-  - block:    ":rocket: Release"
-    prompt:   Create a release, and push it to Sonatype and Github?
-    branches: "master"
+  - name: ":scala: :codeclimate: Run tests and report coverage"
+    command: .buildkite/run-tests-and-coverage
+    timeout_in_minutes: 8
+    plugins:
+      vital-software/docker-compose#vital-v1.8:
+        config:
+          - docker-compose.yml
+          - docker-compose.buildkite.yml
+        run: scala-redox-base
+        log_all: true
+      artifacts#v1.0.0:
+        upload: "target/test-reports/*.xml"
 
-  - label: ":maven: :sbt: Create release"
-    branches: "master"
+  - wait
+
+  - block: ":rocket: Release"
+    prompt: Create a release, and push it to Sonatype and Github?
+    branches: master
+
+  - name: ":maven: :sbt: Create release"
+    branches: master
     command: .buildkite/create-release

--- a/.buildkite/report-compile-problems
+++ b/.buildkite/report-compile-problems
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+mkdir -p compile-logs
+buildkite-agent artifact download "docker-compose-log-all/*scala-redox-base_build*.log" compile-logs --step ":scala: :codeclimate: Run tests and report coverage"
+
+warnings=$(cat compile-logs/**/*.log | \
+  perl -pe 's/\x1b\[[0-9;]*[a-zA-Z]//g' | \
+  sed -nE '/.*Compiling.*/,/.*(Done compiling|Compilation failed).*/p' | \
+  grep '\[warn\]' | \
+  grep -v 'warnings found$' | \
+  sed -E 's/^.*\[warn\] ?//')
+
+errors=$(cat compile-logs/**/*.log | \
+  perl -pe 's/\x1b\[[0-9;]*[a-zA-Z]//g' | \
+  sed -nE '/.*Compiling.*/,/.*(Done compiling|Compilation failed).*/p' | \
+  grep -v 'errors found$' | \
+  grep -v 'Compilation failed$' | \
+  grep '\[error\]' | \
+  sed -E 's/^.*\[error\] ?//')
+
+ret=0
+
+if [[ -n "$warnings" ]]; then
+  echo "+++ :warning: Compile warnings found:"
+  echo "$warnings"
+  echo "Scala compile warnings found:
+
+\`\`\`
+$warnings
+\`\`\`" | buildkite-agent annotate --style 'warning' --context 'scalac-warning'
+  ret=1
+else
+  echo "--- :white_check_mark: No compile warnings found"
+fi
+
+if [[ -n "$errors" ]]; then
+  echo "+++ :x: Compile errors found:"
+  echo "$errors"
+  echo "Scala compile errors found:
+
+\`\`\`
+$errors
+\`\`\`" | buildkite-agent annotate --style 'error' --context 'scalac-error'
+  ret=2
+else
+  echo "--- :white_check_mark: No compile errors found"
+fi
+
+exit $ret

--- a/.buildkite/run-tests-and-coverage
+++ b/.buildkite/run-tests-and-coverage
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+sbt -batch -v coverage test coverageReport
+
+/cc-test-reporter format-coverage target/scala-*/coverage-report/cobertura.xml --input-type=cobertura
+/cc-test-reporter upload-coverage

--- a/.buildkite/store-git-info
+++ b/.buildkite/store-git-info
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo -n "Adding information from git context..." >&2
+GIT_COMMITTED_AT=$(git show -s --format=%ct)
+
+buildkite-agent meta-data set env-GIT_COMMITTED_AT ${GIT_COMMITTED_AT}

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,26 @@
+version: "2"
+checks:
+  # Codeclimate doesn't detect implicit arguments, so this default (4) was a bit
+  # harsh
+  argument-count:
+    enabled: false
+
+# Once this configuration file is committed, the default exclude patterns will
+# no longer be automatically applied, so we relist all the relevant ones here
+exclude_patterns:
+  - .buildkite/
+  - .github/
+  - .idea/
+  - test/
+  - project/
+  - logs/
+  - doc/
+  - "**/*.sbt"
+  - .codeclimate.yml
+
+plugins:
+  fixme:
+    enabled: true
+    config:
+      strings:
+        - FIXME

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
+.git/
+logs/
+.idea/
 target/
-.buildkite
 README.md
 CHANGELOG.md
 LICENSE
 .gitignore
-.git/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Purpose
+_Describe the feature or problem in addition to a link to the issues._
+
+## Approach
+_How does this change address the feature/problem?_
+
+#### Open Questions and Pre-Merge TODOs
+- [ ] Use github checklists. When solved, check the box and explain the answer.
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD project /app/project
 ADD build.sbt /app
 
 # Grab any updated dependencies
-RUN sbt update
+RUN sbt -batch coverage update
 
 # Add rest of sources
 ADD . /app

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# scala-redox
-
-[![Build status](https://badge.buildkite.com/b0bbb5518c0cee6021cd4f31c5ac97537aa0a2a17bf88bee2b.svg)](https://buildkite.com/vital/scala-redox)
+# Scala Redox [![Build status](https://badge.buildkite.com/b0bbb5518c0cee6021cd4f31c5ac97537aa0a2a17bf88bee2b.svg)](https://buildkite.com/vital/scala-redox) [![Test Coverage](https://api.codeclimate.com/v1/badges/c4eaeef835cead5f5717/test_coverage)](https://codeclimate.com/github/vital-software/scala-redox/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/c4eaeef835cead5f5717/maintainability)](https://codeclimate.com/github/vital-software/scala-redox/maintainability)
 
 Scala rest-client (Java compatible) for sending and receiving messages from the Redox healthcare APIs. Messages are sent
-and received asynchronously, returning Future[RedoxResponse[T]] objects that are either a type T or a RedoxErrorResponse 
+and received asynchronously, returning Future[RedoxResponse[T]] objects that are either a type T or a RedoxErrorResponse
 hat can include Json validation/serialization issues or an HTTP status like 403 or 404.
 
 ## Usage
+
 See [tests](https://github.com/vital-software/scala-redox/tree/master/src/test/scala/com/github/vitalsoftware/scalaredox) for usage examples.
 
 ```
@@ -64,20 +63,23 @@ libraryDependencies += "com.github.vital-software" %% "scala-redox" % "2.0.4"
 Tested with Scala 2.11.11
 
 ## Architecture
+
 Data-models available at [Redox](https://developer.redoxengine.com/) have been transcribed into Scala case classes.
 
- - Json serialization/deserialization using Play-Json gives you the full
-   object graph: e.g. `ClinicalSummary.Medications.map(med => med.Route.Code)`
- - Strongly typed. String's in ISO 8601 format for example are converted into joda.DateTime
- - Non-required fields are Option[]
+- Json serialization/deserialization using Play-Json gives you the full
+  object graph: e.g. `ClinicalSummary.Medications.map(med => med.Route.Code)`
+- Strongly typed. String's in ISO 8601 format for example are converted into joda.DateTime
+- Non-required fields are Option[]
 
 ## Dependencies
- - [Play Webservices (WS) standalone HTTP client](https://github.com/playframework/play-ws)
- - [Play-Json 2.6.x](https://github.com/playframework/play-json)
- - Vital's own Scala annotation macros for easy Json.format[T]
- - [Units of Measurement for ISO/UCUM measurements](https://github.com/unitsofmeasurement/uom-systems)
+
+- [Play Webservices (WS) standalone HTTP client](https://github.com/playframework/play-ws)
+- [Play-Json 2.6.x](https://github.com/playframework/play-json)
+- Vital's own Scala annotation macros for easy Json.format[T]
+- [Units of Measurement for ISO/UCUM measurements](https://github.com/unitsofmeasurement/uom-systems)
 
 ## Future Work
+
 Writing objects to Redox is still "hard", meaning you often need to know the Code and CodSystem used. We may bind a
 `CodeProvider` trait that can be extended to provide codes to objects in a flexible way, such that your system
 does not need to know whether a code is Snomed CT or LOINC.
@@ -87,9 +89,11 @@ The same applies to adding units of measurement, with UCUM and ISO measurements 
 It's also possible these will be split into separate repos to keep the rest-client clean.
 
 ## Notes
+
 An attempt was made to reconcile Redox's own internal data-structures, such that the "Provider" for example is the same
 object in Encounter.Providers and Document.Author. This occasionally required adding optional fields that are present
 in one model but not another. For example in models.Observation which is used by models.Result and models.Procedures:
+
 ```
   TargetSite: Option[BasicCode] = None,  // Used by Procedures only
   Interpretation: Option[String] = None  // Used by Result only
@@ -98,4 +102,5 @@ in one model but not another. For example in models.Observation which is used by
 A different approach was taken by the PHP redox client listed below.
 
 ## Links
- - [Redox PHP client from RoundingWell](https://github.com/RoundingWellOS/redox-php)
+
+- [Redox PHP client from RoundingWell](https://github.com/RoundingWellOS/redox-php)

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,11 @@ releaseProcess := Seq[ReleaseStep](
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 
+// Test settings
+Test / testOptions ++= Seq(
+  Tests.Argument("junitxml")
+)
+
 val updateReleaseFiles = ReleaseStep { state =>
   updateLine(
     state,

--- a/docker-compose.buildkite.yml
+++ b/docker-compose.buildkite.yml
@@ -1,0 +1,20 @@
+version: "2.3"
+
+services:
+  scala-redox-base:
+    environment:
+      - BUILDKITE
+      - BUILDKITE_BRANCH
+      - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_BUILD_URL
+      - BUILDKITE_COMMIT
+      - BUILDKITE_PROJECT_SLUG
+      - BUILDKITE_PULL_REQUEST
+      - BUILDKITE_REPO
+      - CC_TEST_REPORTER_ID
+      - CI
+      - REDOX_API_KEY
+      - REDOX_API_SECRET
+    volumes:
+      - "./target/test-reports:/app/target/test-reports"
+      - "./target/scoverage-report:/app/target/scoverage-report"

--- a/docker-compose.buildkite.yml
+++ b/docker-compose.buildkite.yml
@@ -13,6 +13,7 @@ services:
       - BUILDKITE_REPO
       - CC_TEST_REPORTER_ID
       - CI
+      - GIT_COMMITTED_AT
       - REDOX_API_KEY
       - REDOX_API_SECRET
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2.3"
+
+services:
+  scala-redox-base:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: quay.io/vital/scala-redox:base-latest


### PR DESCRIPTION
## Purpose
Brings `scala-redox` tooling inline with our other projects, with the main addition being Test Coverage reporting.

Resolves #25

## Approach
- Run CI commands in Docker container
- Output and upload test coverage reports from JUnit
- Add new badges to Readme file
- Add Github PR template
- Add Code Climate config for Scala
- Add Compile warning/error check to CI

