### PR TITLE
Recover non-array paths recursively

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -45,7 +45,7 @@ object OrderPriorityTypes extends Enumeration {
 
   @transient implicit lazy val jsonFormat: Format[OrderPriorityTypes.Value] = Format(Reads {
     case JsString(v) => JsSuccess(JsString(mappings.getOrElse(v, v)))
-    case _ => JsError("error.expected.jsstring")
+    case _           => JsError("error.expected.jsstring")
   } andThen Reads.enumNameReads(OrderPriorityTypes), Writes.enumNameWrites)
 }
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -87,7 +87,7 @@ object ResultPerformer extends RobustPrimitives
 
 object Result extends RobustPrimitives
 
-// Current overall status of the order. One of the following: "Final", "Preliminary", "In Process", "Corrected", "Canceled".
+// Current overall status of the order. One of the following: "Final", "Preliminary", "In Process", "Corrected", "Canceled", "Other".
 object ResultsStatusTypes extends Enumeration {
   val Final, Preliminary, Corrected, Canceled, Other = Value
   val InProcess = Value("In Process")


### PR DESCRIPTION
## Purpose
There was a bug where `RobustParsing` didn't recover from paths that didn't contain array's recursively.

Which is the cause for https://app.raygun.com/crashreporting/19xzlad/errors/2907626472?dateFrom=2018-12-04T23%3A50%3A00.000Z&dateTo=2018-12-11T23%3A50%3A44.000Z.

This will still log a `Redox conversion of message recovered` error instead of `Redox conversion of message failed`