### PR TITLE
[API-23]: Add endpoint challenge/response and validation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a controller helper trait for responding to Redox endpoint challenges
+  and validating received webhook messages
+
 ## [2.0.5] - 2018-12-12
 
 ### Fixed
+
 - Robust parsing of non-array paths
 
-## [2.0.4] - 2018-11-07
-
-## [2.0.3] - 2018-11-07
-
-## [2.0.2] - 2018-11-07
-
-## [2.0.1] - 2018-10-31
+## [2.0.1] - [2.0.4] - 2018-10-31
 
 ### Fixed
 
@@ -25,15 +25,12 @@
 
 - Remove cross compile code for 2.11 release as there are multiple incompatibilities.
 
-## [1.6.2] - 2018-10-18
-
-## [1.6.1] - 2018-10-17
-
-## [1.6.0] - 2018-09-24
+## [1.6.0] - [1.6.2] - 2018-09-24
 
 - Fixes Locale validation errors by introducing a strict Language type.
 
 #### Breaking
+
 `Patient.Demographics.Language` is changed from java.util.Local to `Language`
 
 
@@ -90,11 +87,7 @@ whenever parsing of that filed fails.
 - Failing to parse an `Enumeration` with `HasDefaultReads` will now fallback to a default value
 and a failure being logged. (except for `SexType`, `DataModel`, `RedoxEventTypes` and `CommonVitalTypes`)
 
-## [1.1.0] - 2018-06-28
-
-## [1.0.2] - 2018-06-28
-
-## [1.0.1] - 2018-06-18
+## [1.0.1] - [1.1.0] - 2018-06-28
 
 ### Changed
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,17 +19,21 @@ resolvers ++= Seq(
   "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 )
 
+val playJsonVersion = "2.6.9"
+val playVersion = "2.6.17"
+
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.6.8",
-  "com.typesafe.play" %% "play-json-joda" % "2.6.8",
-  "com.typesafe.play" %% "play-ahc-ws" % "2.6.12",
-  //"com.typesafe.play" %% "play-ahc-ws-standalone" % "1.1.6",
+  "com.typesafe.play" %% "play-json" % playJsonVersion,
+  "com.typesafe.play" %% "play-json-joda" % playJsonVersion,
+  "com.typesafe.play" %% "play-ahc-ws" % playVersion,
   "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.6",
   "com.typesafe.akka" %% "akka-http" % "10.0.9",
-  //"ai.x" %% "play-json-extensions" % "0.8.0",
+
   "com.github.vital-software" %% "json-annotation" % "0.6.0",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",
-  "org.specs2" %% "specs2-core" % "4.2.0" % Test
+
+  "org.specs2" %% "specs2-core" % "4.2.0" % Test,
+  "com.typesafe.play" %% "play-specs2" % playVersion % Test,
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,6 @@ libraryDependencies ++= Seq(
   "com.github.vital-software" %% "json-annotation" % "0.6.0",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",
 
-  "org.specs2" %% "specs2-core" % "4.2.0" % Test,
   "com.typesafe.play" %% "play-specs2" % playVersion % Test,
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/receiver/ReceiveController.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/receiver/ReceiveController.scala
@@ -1,0 +1,69 @@
+package com.github.vitalsoftware.scalaredox.receiver
+
+import com.github.vitalsoftware.scalaredox.receiver.ReceiveController._
+import com.github.vitalsoftware.util.JsonNaming.KebabCase
+import play.api.libs.json._
+import play.api.mvc._
+import play.api.Logger
+import play.api.libs.json.JsonConfiguration.Aux
+
+import scala.concurrent.Future
+
+trait ReceiveController extends BaseController {
+  val RedoxVerificationToken: String
+  val logger: Logger
+
+  /**
+   * Validate an initial challenge from Redox to authenticate our server as a
+   * destination, or validate a normal Redox event request and delegate to the
+   * verifiedAction
+   *
+   * Redox documentation says:
+   * > Verification POSTs will include a challenge value and your destination’s
+   * > verification token (that you specified when you set up the destination
+   * > record) in the body of the POST. Non-verification POSTs from Redox will
+   * > always include the verification token in the header of the message.
+   *
+   * @see http://developer.redoxengine.com/getting-started/create-a-destination/
+   */
+  private def validatedAction(verifiedAction: RedoxRequest => Future[Result]): Action[JsValue] =
+    Action(parse.json).async({ request: Request[JsValue] =>
+      RedoxRequest(request).token match {
+        case Some(token) if token == RedoxVerificationToken =>
+          verifiedAction(RedoxRequest(request))
+        case Some(token) =>
+          // The verification token is incorrect
+          logger.error(s"Redox webhook had an incorrect token from ${RedoxRequest(request)}")
+          Future.successful(Forbidden(s"Validation failed."))
+        case None =>
+          challengeResponse(RedoxRequest(request))
+      }
+    })
+
+  private def challengeResponse(request: RedoxRequest): Future[Result] = request.underlying.body.validate[Challenge].fold(
+    (errors: Seq[(JsPath, Seq[JsonValidationError])]) => {
+      // The challenge has an invalid format
+      logger.error(s"Redox webhook challenge had errors (${JsError.toJson(errors)}) from $request")
+      logger.debug(s"Failed challenge body was: ${request.underlying.body.toString()}")
+      Future.successful(Forbidden(s"Challenge failed."))
+    },
+    (challenge: Challenge) => {
+      if (challenge.verificationToken == RedoxVerificationToken) {
+        // The challenge is successful: we must respond with the challenge token (only)
+        logger.info(s"Redox endpoint initialized via challenge from $request")
+        Future.successful(Ok(challenge.challenge))
+      } else {
+        // The challenge has an invalid validation token
+        logger.error(s"Redox challenge had invalid token from $request")
+        Future.successful(Forbidden(s"Challenge failed."))
+      }
+    }
+  )
+}
+
+object ReceiveController {
+  case class Challenge(verificationToken: String, challenge: String)
+
+  implicit val config: Aux[Json.MacroOptions] = JsonConfiguration(KebabCase)
+  implicit val challengeFormat: Format[Challenge] = Json.format[Challenge]
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/receiver/RedoxRequest.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/receiver/RedoxRequest.scala
@@ -1,0 +1,22 @@
+package com.github.vitalsoftware.scalaredox.receiver
+
+import com.google.common.base.MoreObjects
+import play.api.libs.json.JsValue
+import play.api.mvc.Request
+import com.github.vitalsoftware.scalaredox.receiver.RedoxRequest.TokenHeader
+
+case class RedoxRequest(underlying: Request[JsValue]) {
+  override def toString: String = MoreObjects.toStringHelper(this)
+    .add("host", underlying.host)
+    .add("remoteAddress", underlying.remoteAddress)
+    .add("method", underlying.method)
+    .add("path", underlying.path)
+    .add("tokenHeader", token.getOrElse("unspecified"))
+    .toString
+
+  val token: Option[String] = underlying.headers.get(TokenHeader)
+}
+
+object RedoxRequest {
+  final val TokenHeader: String = "verification-token"
+}

--- a/src/main/scala/com/github/vitalsoftware/util/JsonNaming.scala
+++ b/src/main/scala/com/github/vitalsoftware/util/JsonNaming.scala
@@ -1,0 +1,43 @@
+package com.github.vitalsoftware.util
+
+import play.api.libs.json.{ JsonNaming => Naming }
+
+object JsonNaming {
+  /**
+   * For each class property, use the kebab case equivalent
+   * to name its column (e.g. fooBar -> foo-bar).
+   *
+   * Based on play.api.libs.json.JsonNaming.SnakeCase
+   */
+  object KebabCase extends Naming {
+    override val toString = "KebabCase"
+
+    def apply(property: String): String = {
+      val length = property.length
+      val result = new StringBuilder(length * 2)
+      var resultLength = 0
+      var wasPrevTranslated = false
+      for (i <- 0 until length) {
+        var c = property.charAt(i)
+        if (i > 0 || i != '-') {
+          if (Character.isUpperCase(c)) {
+            // append a hyphen if the previous result wasn't translated
+            if (!wasPrevTranslated && resultLength > 0 && result.charAt(resultLength - 1) != '-') {
+              result.append('-')
+              resultLength += 1
+            }
+            c = Character.toLowerCase(c)
+            wasPrevTranslated = true
+          } else {
+            wasPrevTranslated = false
+          }
+          result.append(c)
+          resultLength += 1
+        }
+      }
+
+      // builds the final string
+      result.toString()
+    }
+  }
+}

--- a/src/test/scala/com/github/vitalsoftware/helpers/WithApplication.scala
+++ b/src/test/scala/com/github/vitalsoftware/helpers/WithApplication.scala
@@ -1,0 +1,30 @@
+package com.github.vitalsoftware.helpers
+
+import org.specs2.specification.AfterAll
+import play.api
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.{ DefaultAwaitTimeout, FutureAwaits, Injecting }
+import play.api.{ Configuration, Environment, Mode }
+
+/**
+ * Global trait version of WithApplication provided by Play
+ *
+ * The WithApplication provided by Play is implemented as a Context object
+ * so it does not support nested tests. This means it shuts down and starts
+ * up the application for every individual test case.
+ *
+ * This trait is implemented on the test class/object as a whole, and
+ * uses a single application instance for all the individual test cases within.
+ */
+trait WithApplication extends AfterAll with DefaultAwaitTimeout with FutureAwaits with Injecting {
+  lazy val app: api.Application = builder.build()
+
+  override def afterAll(): Unit = {
+    await(app.stop())
+    ()
+  }
+
+  protected def builder: GuiceApplicationBuilder = GuiceApplicationBuilder()
+    .in(Mode.Test)
+    .configure(Configuration.load(Environment.simple()))
+}

--- a/src/test/scala/com/github/vitalsoftware/helpers/WithReceiveController.scala
+++ b/src/test/scala/com/github/vitalsoftware/helpers/WithReceiveController.scala
@@ -1,0 +1,40 @@
+package com.github.vitalsoftware.helpers
+
+import com.github.vitalsoftware.helpers.WithReceiveController.ReceiveController
+import play.api.Application
+import play.api.mvc.{ Request, Result }
+import play.api.test.Injecting
+import com.github.vitalsoftware.scalaredox.receiver.{ RedoxRequest, ReceiveController => BaseReceiveController }
+import javax.inject.Inject
+import play.api.Logger
+import play.api.libs.json.JsValue
+import play.api.mvc.{ Action, ControllerComponents }
+
+import scala.concurrent.Future
+
+/**
+ * Trait for tests and context objects involving the receive controller
+ */
+trait WithReceiveController
+  extends Injecting
+{
+  val app: Application
+
+  lazy protected val controller: ReceiveController = inject[ReceiveController]
+
+  def receive(req: Request[JsValue]): Future[Result] = controller.receive().apply(req)
+}
+
+object WithReceiveController {
+  final val ValidToken = "foo"
+  final val InvalidToken = "bar"
+
+  class ReceiveController @Inject() (val controllerComponents: ControllerComponents) extends BaseReceiveController {
+    override val logger: Logger = play.api.Logger(this.getClass)
+    override val verificationToken: String = WithReceiveController.ValidToken
+
+    def receive: Action[JsValue] = validatedAction { request: RedoxRequest =>
+      Future.successful(Ok("Done"))
+    }
+  }
+}

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/receiver/ReceiveControllerTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/receiver/ReceiveControllerTest.scala
@@ -1,0 +1,89 @@
+package com.github.vitalsoftware.scalaredox.receiver
+
+import com.github.vitalsoftware.helpers.{ WithApplication, WithReceiveController }
+import org.specs2.matcher.Matchers
+import org.specs2.mock.Mockito
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json._
+import play.api.mvc.{ Request, Result, Results }
+import play.api.test._
+import play.api.{ Configuration, Environment }
+import RedoxRequest.TokenHeader
+
+import scala.concurrent.Future
+
+/**
+ * Test that actually communicates with a Kinesis endpoint (e.g. via a Kinesalite
+ * container in development environments)
+ */
+object ReceiveControllerTest extends PlaySpecification
+  with Results
+  with Matchers
+  with Mockito
+  with WithApplication
+  with WithReceiveController {
+
+  private final val Request = FakeRequest()
+    .withBody(Json.obj("foo" -> "bar"))
+
+  private val environment = Environment.simple()
+
+  override protected def builder: GuiceApplicationBuilder = super.builder
+    .configure(Configuration.load(environment) ++ Configuration.from(Map(
+      "redox-receiver.verificationToken" -> WithReceiveController.ValidToken
+    )))
+
+  // --- Tests --- //
+
+  "ReceiveController" should {
+    "provide a /receive route" in {
+      def receive(req: Request[JsValue]): Future[Result] = controller.receive().apply(req)
+
+      "that allows requests with valid tokens" in {
+        "and processes normal payloads" in {
+          val res: Future[Result] = receive(
+            Request
+              .withHeaders(TokenHeader -> WithReceiveController.ValidToken)
+              .withBody(Json.obj("foo" -> "bar"))
+          )
+
+          status(res) mustEqual OK
+          header("Cookie", res) must beNone
+        }
+      }
+
+      "that blocks invalid requests with no token" in {
+        status(receive(Request)) mustEqual FORBIDDEN
+      }
+
+      "that blocks invalid requests with bad tokens" in {
+        status(receive(Request.withHeaders(
+          TokenHeader -> WithReceiveController.InvalidToken
+        ))) mustEqual FORBIDDEN
+      }
+
+      "that responds to valid challenge requests" in {
+        val result = receive(Request.withBody(Json.obj(
+          "challenge" -> "something",
+          "verification-token" -> WithReceiveController.ValidToken
+        )))
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual "something"
+      }
+
+      "that blocks invalid challenge requests with no token" in {
+        status(receive(Request.withBody(Json.obj(
+          "challenge" -> "something",
+        )))) mustEqual FORBIDDEN
+      }
+
+      "that blocks invalid challenge requests with bad tokens" in {
+        status(receive(Request.withBody(Json.obj(
+          "challenge" -> "something",
+          "verification-token" -> WithReceiveController.InvalidToken
+        )))) mustEqual FORBIDDEN
+      }
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.6-SNAPSHOT"
+version in ThisBuild := "2.1.0-SNAPSHOT"


### PR DESCRIPTION
Adds ReceiveController, an abstract trait that can be used to implement a validated webhook-receiving endpoint for Redox messages.

Previously, this logic lived in individual projects that processed messages from Redox. Now, we'd like more than one other project to be able to validate Redox webhooks (in this particular case, for implementing R^SSO support), so we have cause to move this validation logic into scala-redox.