### PR TITLE
[API-87] Resolve: Manage multiple credentials for multiple sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ usage is only advisable if application has a single source .
 - Added HttpClient interface to allow using different http client under the hood.
 - ClientConfig object standerdizes the configuration values that's needed
 to be passed into RedoxClient.
->>>>>>> f9cf54d... update changelog and version
 
 ## [2.1.0] - 2019-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,29 @@
 
 ## [Unreleased]
 
+Adds the ability to handle multiple credentials for multiple sources.
+
+Each source in Redox has a unique set of api-key, api-secret credentials.
+If a client has multiple sources, this would have required creating multiple
+RedoxClients per each source.
+
+However, Redox-client constructed an internal WsClient (httpClient) and a akka
+schedule to manage the access-refresh Token lifecycle. This consumes
+unnecessary resources as each client would have created its own thread pool.
+
 ### Changed
+- Breaking: RedoxClient is completely redesigned to take in an external
+Http client. A secondary constructor is added for easier migration. However,
+usage is only advisable if application has a single source .
 
 - Marked one property on the ReceiveController protected
+
+### Added
+- RedoxTokenManager to manage Redox tokens for multiple sources.
+- Added HttpClient interface to allow using different http client under the hood.
+- ClientConfig object standerdizes the configuration values that's needed
+to be passed into RedoxClient.
+>>>>>>> f9cf54d... update changelog and version
 
 ## [2.1.0] - 2019-01-18
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % playJsonVersion,
   "com.typesafe.play" %% "play-json-joda" % playJsonVersion,
   "com.typesafe.play" %% "play-ahc-ws" % playVersion,
-  "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.6",
-  "com.typesafe.akka" %% "akka-http" % "10.0.9",
+  "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.2",
+  "com.typesafe.akka" %% "akka-http" % "10.0.14",
 
   "com.github.vital-software" %% "json-annotation" % "0.6.0",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/HttpClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/HttpClient.scala
@@ -1,0 +1,33 @@
+package com.github.vitalsoftware.scalaredox.client
+
+import java.io.Closeable
+
+import play.api.libs.ws.ahc.StandaloneAhcWSClient
+import play.api.libs.ws.{ StandaloneWSRequest, WSClient }
+
+/**
+ * Designed to unify interfaces of play.api.libs.ws.StandaloneWSClient and play.api.libs.ws.WSClient
+ * so that these can be used interchangeably. Can be used to accommodate play's internal WsClient or
+ * StandaloneAhcWSClient bundled with the library.
+ */
+trait HttpClient extends Closeable {
+  def url(url: String): StandaloneWSRequest
+}
+
+object HttpClient {
+  implicit def fromWsClient(wsClient: WSClient) = new HttpClient {
+    def url(url: String): StandaloneWSRequest = wsClient.url(url)
+
+    /**
+     * Calling this is probably risky as wsClient might get created from DI container and injected.
+     * So this basically does nothing. If WsClient is used, it is expected that the caller handles releasing resources.
+     */
+    override def close(): Unit = wsClient.close()
+  }
+
+  implicit def fromStandaloneAhcWSClient(standaloneAhcWSClient: StandaloneAhcWSClient) = new HttpClient {
+    override def url(url: String): StandaloneWSRequest = standaloneAhcWSClient.url(url)
+
+    override def close(): Unit = standaloneAhcWSClient.close()
+  }
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/HttpClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/HttpClient.scala
@@ -24,7 +24,7 @@ object HttpClient {
      * Calling this is probably risky as wsClient might get created from DI container and injected.
      * So this basically does nothing. If WsClient is used, it is expected that the caller handles releasing resources.
      */
-    override def close(): Unit = wsClient.close()
+    override def close(): Unit = Unit
   }
 
   implicit def fromStandaloneAhcWSClient(standaloneAhcWSClient: StandaloneAhcWSClient) = new HttpClient {

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/HttpClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/HttpClient.scala
@@ -5,6 +5,8 @@ import java.io.Closeable
 import play.api.libs.ws.ahc.StandaloneAhcWSClient
 import play.api.libs.ws.{ StandaloneWSRequest, WSClient }
 
+import scala.language.implicitConversions
+
 /**
  * Designed to unify interfaces of play.api.libs.ws.StandaloneWSClient and play.api.libs.ws.WSClient
  * so that these can be used interchangeably. Can be used to accommodate play's internal WsClient or

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ FileIO, Source }
 import com.github.vitalsoftware.scalaredox._
 import com.github.vitalsoftware.scalaredox.models.Upload
@@ -30,7 +30,7 @@ class RedoxClient(
   reducer: JsValue => JsValue = _.reduceNullSubtrees
 )(
   implicit val system: ActorSystem,
-  implicit val materializer: ActorMaterializer,
+  implicit val materializer: Materializer,
 ) extends RedoxClientComponents(client, conf.baseRestUri, reducer) {
 
   /**
@@ -43,7 +43,7 @@ class RedoxClient(
     conf: Config,
     client: HttpClient,
     reducer: JsValue => JsValue
-  )(implicit system: ActorSystem, materializer: ActorMaterializer) = {
+  )(implicit system: ActorSystem, materializer: Materializer) = {
     this(conf, client, new RedoxTokenManager(client, ClientConfig(conf).baseRestUri), reducer)
   }
 
@@ -56,7 +56,7 @@ class RedoxClient(
    */
   def this(
     conf: Config
-  )(implicit system: ActorSystem, materializer: ActorMaterializer) {
+  )(implicit system: ActorSystem, materializer: Materializer) {
     this(conf, StandaloneAhcWSClient(), _.reduceEmptySubtrees)
   }
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -30,78 +30,48 @@ import scala.util.{ Failure, Success, Try }
  * Created by apatzer on 3/20/17.
  */
 class RedoxClient(
-  conf: Config,
+  conf: ClientConfig,
+  client: HttpClient,
+  tokenManager: RedoxTokenManager,
+  reducer: JsValue => JsValue = _.reduceNullSubtrees
+)(
   implicit val system: ActorSystem,
   implicit val materializer: ActorMaterializer,
-  reducer: JsValue => JsValue = _.reduceNullSubtrees
-) {
+) extends RedoxClientComponents(client, conf.baseRestUri, reducer) {
 
-  private val client = StandaloneAhcWSClient()
-
-  private[client] val apiKey = conf.getString("redox.apiKey")
-  private[client] val apiSecret = conf.getString("redox.secret")
-  private[client] val baseRestUri = Uri(conf.getString("redox.restApiBase"))
-  private[client] lazy val authInfo = {
-    val auth = new SyncVar[Option[AuthInfo]]
-    auth.put(None)
-    auth
+  /**
+   * Initialize and internal HttpClient and a token manager. Added for backward compatibility.
+   * @deprecated prefer initializing the HttpClient and token manager outside RedoxClient. Do not create
+   *             more than one RedoxClient with this constructor as it will initialize duplicate
+   *             TokenManagers and http clients.
+   */
+  def this(
+    conf: Config,
+    client: HttpClient,
+    reducer: JsValue => JsValue
+  )(implicit system: ActorSystem, materializer: ActorMaterializer) = {
+    this(conf, client, new RedoxTokenManager(client, ClientConfig(conf).baseRestUri), reducer)
   }
 
-  private def baseRequest(url: String) = client.url(url)
-  private def baseQuery = baseRequest(baseRestUri.withPath(/("query")).toString()).withMethod("POST")
-  private def basePost = baseRequest(baseRestUri.withPath(/("endpoint")).toString()).withMethod("POST")
-  private def baseUpload = baseRequest(baseRestUri.withPath(/("upload")).toString()).withMethod("POST")
+  /**
+   * Use default reducer, with internally initialized http client and token manager.
+   *
+   * @deprecated prefer initializing the HttpClient and token manager outside RedoxClient. Do not create
+   *             more than one RedoxClient with this constructor as it will initialize duplicate
+   *             TokenManagers and http clients.
+   */
+  def this(
+    conf: Config
+  )(implicit system: ActorSystem, materializer: ActorMaterializer) {
+    this(conf, StandaloneAhcWSClient(), _.reduceEmptySubtrees)
+  }
 
   /** Send and receive an authorized request */
   private def sendReceive[T](request: StandaloneWSRequest)(implicit format: Reads[T]): Future[RedoxResponse[T]] = {
     for {
-      auth <- authInfo.get match {
-        case Some(info) => Future.successful(info)
-        case None       => setAuthAndScheduleRefresh(authorize())
-      }
+      auth <- tokenManager.getAccessToken(conf.apiKey, conf.apiSecret)
       response <- execute[T](request.addHttpHeaders("Authorization" -> s"Bearer ${auth.accessToken}"))
     } yield response
-  }
-
-  /** Raw request execution */
-  private def execute[T](request: StandaloneWSRequest)(implicit format: Reads[T]): Future[RedoxResponse[T]] = {
-    request.execute().map {
-
-      // Failure status
-      case r if Set[StatusCode](
-        BadRequest,
-        Unauthorized,
-        Forbidden,
-        NotFound,
-        MethodNotAllowed,
-        RequestedRangeNotSatisfiable
-      ).contains(r.status) =>
-        Try {
-          // In case we do not get valid JSON back, wrap everything in a Try block
-          (r.body[JsValue] \ "Meta").as[RedoxErrorResponse]
-        } match {
-          case Success(t) => Left(t)
-          case Failure(e) => Left(RedoxErrorResponse.simple(r.statusText, r.body))
-        }
-
-      // Success status
-      case r =>
-        if (r.body.isEmpty) {
-          Right(EmptyResponse.asInstanceOf[T])
-        } else {
-          val json = reducer(r.body[JsValue])
-
-          Json.fromJson(json).fold(
-            // Json to Scala objects failed...force into RedoxError format
-            invalid = err => Left(RedoxErrorResponse.fromJsError(JsError(err))),
-
-            // All good
-            valid = t => Right(t)
-          )
-        }
-    }.map { response =>
-      RedoxResponse[T](response)
-    }
   }
 
   private def optionalQueryParam[T](
@@ -110,58 +80,6 @@ class RedoxClient(
     f: T => String = (o: T) => o.toString
   ): Map[String, String] = {
     el.map(e => Map(key -> f(e))).getOrElse(Map.empty)
-  }
-
-  /** Authorize to Redox, returning a Future containing the access and refresh tokens. */
-  def authorize(): Future[AuthInfo] = {
-    val req = baseRequest(baseRestUri.withPath(/("auth") / "authenticate").toString())
-      .withMethod("POST")
-      .withBody(Json.toJson(AuthRequest(apiKey = apiKey, secret = apiSecret)))
-    execute[AuthInfo](req).map { result =>
-      parseAuthResponse(result, "Cannot authenticate. Check configuration 'redox.apiKey' & 'redox.secret'")
-    }
-  }
-
-  /**
-   * Refresh the auth token a minute before it expires. Set and schedule a new refresh to occur.
-   * NOTE: If this method is overridden, scheduling and storing the new auth token will
-   * not be available to the implementing class.
-   */
-  protected def scheduleRefresh(auth: AuthInfo): Unit = {
-    val delay = auth.expires.getMillis - DateTime.now.getMillis - 60 * 1000
-    system.scheduler.scheduleOnce(delay.millis) {
-      setAuthAndScheduleRefresh(refresh(auth))
-    }
-  }
-
-  /** Refresh the access and refresh tokens. */
-  def refresh(auth: AuthInfo): Future[AuthInfo] = {
-    val req = baseRequest(baseRestUri.withPath(/("auth") / "refreshToken").toString())
-      .withMethod("POST")
-      .withBody(Json.toJson(RefreshRequest(apiKey = apiKey, refreshToken = auth.refreshToken)))
-    sendReceive[AuthInfo](req).map(result => parseAuthResponse(result, "Cannot refresh OAuth2 token"))
-  }
-
-  /** Set a thread-safe auth-token, and schedule a refresh. */
-  private def setAuthAndScheduleRefresh(authFuture: Future[AuthInfo]): Future[AuthInfo] = {
-    authFuture
-      .map { auth =>
-        authInfo.take()
-        authInfo.put(Some(auth))
-        auth
-      }
-      .map { auth =>
-        scheduleRefresh(auth)
-        auth
-      }
-  }
-
-  /** Parse the result of an auth request, either returning a new AuthInfo object, or throwing an error. */
-  private def parseAuthResponse(authResult: RedoxResponse[AuthInfo], errMsg: String) = {
-    authResult.result.fold(
-      error => throw RedoxAuthorizationException(s"$errMsg: ${error.Errors.map(_.Text).mkString(",")}"),
-      identity
-    )
   }
 
   /**
@@ -252,5 +170,16 @@ object RedoxClient {
       case Left(error)  => (Some(JsError(error)), None)
       case Right(reads) => RobustParsing.robustParsing(reads, reducer(json))
     }
+  }
+}
+
+case class ClientConfig(baseRestUri: Uri, apiKey: String, apiSecret: String)
+object ClientConfig {
+  implicit def apply(conf: Config): ClientConfig = {
+    val apiKey = conf.getString("redox.apiKey")
+    val apiSecret = conf.getString("redox.secret")
+    val baseRestUri = Uri(conf.getString("redox.restApiBase"))
+
+    ClientConfig(baseRestUri, apiKey, apiSecret)
   }
 }

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -3,28 +3,22 @@ package com.github.vitalsoftware.scalaredox.client
 import java.io.File
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.Uri.Path._
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ FileIO, Source }
 import com.github.vitalsoftware.scalaredox._
-import com.github.vitalsoftware.scalaredox.models.{ MediaMessage, Upload }
+import com.github.vitalsoftware.scalaredox.models.Upload
 import com.github.vitalsoftware.util.JsonImplicits.JsValueExtensions
 import com.github.vitalsoftware.util.RobustParsing
 import com.typesafe.config.Config
-import org.joda.time.DateTime
 import play.api.libs.json._
-import play.api.libs.ws.JsonBodyReadables._
-import play.api.libs.ws.JsonBodyWritables._
 import play.api.libs.ws._
 import play.api.libs.ws.ahc._
 import play.api.mvc.MultipartFormData.FilePart
 
 import scala.concurrent.ExecutionContext.Implicits._
-import scala.concurrent.duration._
-import scala.concurrent.{ Future, SyncVar }
-import scala.util.{ Failure, Success, Try }
+import scala.concurrent.Future
+import scala.language.implicitConversions
 
 /**
  * Created by apatzer on 3/20/17.

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
@@ -1,0 +1,65 @@
+package com.github.vitalsoftware.scalaredox.client
+
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.Uri.Path._
+import akka.http.scaladsl.model._
+import play.api.libs.json._
+import play.api.libs.ws._
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
+
+abstract class RedoxClientComponents(
+  client: HttpClient,
+  baseRestUri: Uri,
+  reducer: JsValue => JsValue
+)(
+  implicit
+  ec: ExecutionContext
+) {
+  protected def baseRequest(url: String) = client.url(url)
+  protected def baseQuery = baseRequest(baseRestUri.withPath(/("query")).toString()).withMethod("POST")
+  protected def basePost = baseRequest(baseRestUri.withPath(/("endpoint")).toString()).withMethod("POST")
+  protected def baseUpload = baseRequest(baseRestUri.withPath(/("upload")).toString()).withMethod("POST")
+
+  /** Raw request execution */
+  protected def execute[T](request: StandaloneWSRequest)(implicit format: Reads[T]): Future[RedoxResponse[T]] = {
+    request.execute().map {
+
+      // Failure status
+      case r if Set[StatusCode](
+        BadRequest,
+        Unauthorized,
+        Forbidden,
+        NotFound,
+        MethodNotAllowed,
+        RequestedRangeNotSatisfiable
+      ).contains(r.status) =>
+        Try {
+          // In case we do not get valid JSON back, wrap everything in a Try block
+          (r.body[JsValue] \ "Meta").as[RedoxErrorResponse]
+        } match {
+          case Success(t) => Left(t)
+          case Failure(e) => Left(RedoxErrorResponse.simple(r.statusText, r.body))
+        }
+
+      // Success status
+      case r =>
+        if (r.body.isEmpty) {
+          Right(EmptyResponse.asInstanceOf[T])
+        } else {
+          val json = reducer(r.body[JsValue])
+
+          Json.fromJson(json).fold(
+            // Json to Scala objects failed...force into RedoxError format
+            invalid = err => Left(RedoxErrorResponse.fromJsError(JsError(err))),
+
+            // All good
+            valid = t => Right(t)
+          )
+        }
+    }.map { response =>
+      RedoxResponse[T](response)
+    }
+  }
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxTokenManager.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxTokenManager.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
  *  We use the RefreshToken obtained from the first request to obtain new accessTokens as they expire.
  *
  *  The RedoxTokenManager schedules the refresh and storage of accessTokens and keeps them valid,
- *  so a client don't have to authenticate each time it makes a request.
+ *  so a client doesn't have to authenticate each time it makes a request.
  *
  *  @param client com.github.vitalsoftware.scalaredox.client.HttpClient instance
  *  @param baseRestUri the base url for Redox REST endpoint.
@@ -49,14 +49,14 @@ class RedoxTokenManager(
   def getAccessToken(apiKey: String, apiSecret: String): Future[AuthInfo] = {
     TokenStore.get(apiKey).map(Future.successful(_))
       .getOrElse {
-        val authInfo = authorize(apiKey, apiSecret)
+        val authInfo = authenticate(apiKey, apiSecret)
         authInfo.foreach(setAuthAndScheduleRefresh(apiKey, _))
         authInfo
       }
   }
 
   /** Authorize to Redox, returning a Future containing the access and refresh tokens. */
-  protected def authorize(apiKey: String, apiSecret: String): Future[AuthInfo] = {
+  protected def authenticate(apiKey: String, apiSecret: String): Future[AuthInfo] = {
     val req = baseRequest(baseRestUri.withPath(/("auth") / "authenticate").toString())
       .withMethod("POST")
       .withBody(Json.toJson(AuthRequest(apiKey = apiKey, secret = apiSecret)))

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxTokenManager.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxTokenManager.scala
@@ -1,0 +1,102 @@
+package com.github.vitalsoftware.scalaredox.client
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path./
+import akka.stream.Materializer
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
+
+/**
+ * Redox uses a perishable accessToken with an expiry to authenticate requests. The accessToken is obtained by
+ * exchanging a apiKey and an apiSecret. On the first exchange we receive:
+ *  1. accessToken
+ *  2. expiry time
+ *  3. refreshToken
+ *
+ *  We use the RefreshToken obtained from the first request to obtain new accessTokens as they expire.
+ *
+ *  The RedoxTokenManager schedules the refresh and storage of accessTokens and keeps them valid,
+ *  so a client don't have to authenticate each time it makes a request.
+ *
+ *  @param client com.github.vitalsoftware.scalaredox.client.HttpClient instance
+ *  @param baseRestUri the base url for Redox REST endpoint.
+ */
+class RedoxTokenManager(
+  client: HttpClient,
+  baseRestUri: Uri
+)(implicit
+  actorSystem: ActorSystem,
+  materializer: Materializer
+) extends RedoxClientComponents(client, baseRestUri, identity) {
+
+  private val RefreshBuffer = 1.minute
+
+  /**
+   * Maps an apiKey to fetched AuthInfo.
+   */
+  private val TokenStore: TrieMap[String, AuthInfo] = TrieMap.empty
+
+  /**
+   * Returns an access token for given credentials. If the access token doesn't exist,
+   * authorize with Redox to obtain a new access token.
+   */
+  def getAccessToken(apiKey: String, apiSecret: String): Future[AuthInfo] = {
+    TokenStore.get(apiKey).map(Future.successful(_))
+      .getOrElse {
+        val authInfo = authorize(apiKey, apiSecret)
+        authInfo.foreach(setAuthAndScheduleRefresh(apiKey, _))
+        authInfo
+      }
+  }
+
+  /** Authorize to Redox, returning a Future containing the access and refresh tokens. */
+  protected def authorize(apiKey: String, apiSecret: String): Future[AuthInfo] = {
+    val req = baseRequest(baseRestUri.withPath(/("auth") / "authenticate").toString())
+      .withMethod("POST")
+      .withBody(Json.toJson(AuthRequest(apiKey = apiKey, secret = apiSecret)))
+    execute[AuthInfo](req).map { result =>
+      parseAuthResponse(result, "Cannot authenticate. Check configuration 'redox.apiKey' & 'redox.secret'")
+    }
+  }
+
+  /** Set a thread-safe auth-token, and schedule a refresh. */
+  private def setAuthAndScheduleRefresh(apiKey: String, authInfo: AuthInfo): Unit = {
+    TokenStore.update(apiKey, authInfo)
+    scheduleRefresh(apiKey: String, authInfo)
+  }
+
+  /**
+   * Refresh the auth token a minute before it expires. Set and schedule a new refresh to occur.
+   * NOTE: If this method is overridden, scheduling and storing the new auth token will
+   * not be available to the implementing class.
+   */
+  protected def scheduleRefresh(apiKey: String, auth: AuthInfo): Unit = {
+    val delay = auth.expires.getMillis - DateTime.now.getMillis - RefreshBuffer.toMillis
+    actorSystem.scheduler.scheduleOnce(delay.millis) {
+      refresh(apiKey, auth).foreach(setAuthAndScheduleRefresh(apiKey, _))
+    }
+  }
+
+  /** Refresh the access and refresh tokens. */
+  protected def refresh(apiKey: String, auth: AuthInfo): Future[AuthInfo] = {
+    val req = baseRequest(baseRestUri.withPath(/("auth") / "refreshToken").toString())
+      .withMethod("POST")
+      .withBody(Json.toJson(RefreshRequest(apiKey = apiKey, refreshToken = auth.refreshToken)))
+    execute[AuthInfo](req).map(result => parseAuthResponse(result, "Cannot refresh OAuth2 token"))
+  }
+
+  /** Parse the result of an auth request, either returning a new AuthInfo object, or throwing an error. */
+  private def parseAuthResponse(authResult: RedoxResponse[AuthInfo], errMsg: String) = {
+    authResult.result.fold(
+      error => throw RedoxAuthorizationException(s"$errMsg: ${error.Errors.map(_.Text).mkString(",")}"),
+      identity
+    )
+  }
+
+}

--- a/src/test/scala/com/github/vitalsoftware/helpers/WithReceiveController.scala
+++ b/src/test/scala/com/github/vitalsoftware/helpers/WithReceiveController.scala
@@ -16,8 +16,7 @@ import scala.concurrent.Future
  * Trait for tests and context objects involving the receive controller
  */
 trait WithReceiveController
-  extends Injecting
-{
+  extends Injecting {
   val app: Application
 
   lazy protected val controller: ReceiveController = inject[ReceiveController]

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
@@ -1,15 +1,14 @@
 package com.github.vitalsoftware.scalaredox
 
 import com.github.vitalsoftware.scalaredox.client.{ AuthInfo, RedoxTokenManager }
-import com.github.vitalsoftware.scalaredox.models._
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
-import play.api.libs.json.{ JsError, Json }
+import play.api.libs.json.Json
 import play.api.routing.sird._
 import play.api.test.WsTestClient
 import play.core.server.Server
 
-import concurrent.{ Await, Future }
+import concurrent.Await
 import scala.concurrent.duration._
 
 class ConnectionTest extends Specification with RedoxTest {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ConnectionTest.scala
@@ -1,10 +1,13 @@
 package com.github.vitalsoftware.scalaredox
 
-import com.github.vitalsoftware.scalaredox.client.AuthInfo
+import com.github.vitalsoftware.scalaredox.client.{ AuthInfo, RedoxTokenManager }
 import com.github.vitalsoftware.scalaredox.models._
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 import play.api.libs.json.{ JsError, Json }
+import play.api.routing.sird._
+import play.api.test.WsTestClient
+import play.core.server.Server
 
 import concurrent.{ Await, Future }
 import scala.concurrent.duration._
@@ -20,7 +23,7 @@ class ConnectionTest extends Specification with RedoxTest {
   "authorize" should {
 
     "return an auth token" in {
-      val fut = client.authorize()
+      val fut = tokenManager.getAccessToken(conf.apiKey, conf.apiSecret)
       val auth = Await.result(fut, timeout)
       validateAuth(auth)
     }
@@ -29,11 +32,49 @@ class ConnectionTest extends Specification with RedoxTest {
   "refresh token" should {
 
     "obtain then refresh an auth token" in {
-      val f1 = client.authorize()
-      val auth1 = Await.result(f1, timeout)
-      val f2 = client.refresh(auth1)
-      val auth2 = Await.result(f2, timeout)
-      validateAuth(auth2)
+      // create a fake server response
+      Server.withRouterFromComponents() { components =>
+        import play.api.mvc.Results._
+        import components.{ defaultActionBuilder => Action }
+      {
+        case POST(p"/auth/authenticate") => Action {
+          Ok(Json.obj(
+            "accessToken" -> "access",
+            // expires in 1 minute 4 seconds
+            // should trigger an refresh in 4 seconds as the RefreshBuffer is 1 minute
+            "expires" -> new DateTime(DateTime.now().getMillis + 1.minute.toMillis + 4.seconds.toMillis).toString,
+            "refreshToken" -> "4ed7b234-9bde-4a9c-9c86-e1bc6e535321",
+          ))
+        }
+        case POST(p"/auth/refreshToken") => Action {
+          Ok(Json.obj(
+            "accessToken" -> "refreshed",
+            // let time for test to pass
+            "expires" -> new DateTime(DateTime.now().getMillis + 1.minute.toMillis + 1.minute.toMillis).toString,
+            "refreshToken" -> "4ed7b234-9bde-4a9c-9c86-e1bc6e535321",
+          ))
+        }
+      }
+      } { implicit port =>
+        WsTestClient.withClient { httpClient =>
+          val tokenManager = new RedoxTokenManager(httpClient, "/auth")
+
+          val f1 = tokenManager.getAccessToken(conf.apiKey, conf.apiSecret)
+          val auth1 = Await.result(f1, timeout)
+          auth1.accessToken mustEqual ("access")
+
+          val f2 = tokenManager.getAccessToken(conf.apiKey, conf.apiSecret)
+          val auth2 = Await.result(f2, timeout)
+          auth2.accessToken mustEqual ("access")
+
+          // wait 5 seconds
+          Thread.sleep(5.seconds.toMillis)
+
+          val f3 = tokenManager.getAccessToken(conf.apiKey, conf.apiSecret)
+          val auth3 = Await.result(f3, timeout)
+          auth3.accessToken mustEqual ("refreshed")
+        }
+      }
     }
   }
 }

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
@@ -21,7 +21,6 @@ trait RedoxTest {
   implicit val system = ActorSystem("redox-test")
   implicit val materializer = ActorMaterializer()(system)
 
-
   val tokenManager = new RedoxTokenManager(httpClient, conf.baseRestUri)
   val client = new RedoxClient(conf, httpClient, tokenManager)
   val timeout: FiniteDuration = 20.seconds

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
@@ -2,10 +2,11 @@ package com.github.vitalsoftware.scalaredox
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.github.vitalsoftware.scalaredox.client.{ RedoxClient, RedoxResponse }
+import com.github.vitalsoftware.scalaredox.client.{ ClientConfig, RedoxClient, RedoxResponse, RedoxTokenManager }
 import com.github.vitalsoftware.util.JsonImplicits.JsValueExtensions
 import com.typesafe.config.ConfigFactory
 import play.api.libs.json.{ JsError, Json, Reads }
+import play.api.libs.ws.ahc.StandaloneAhcWSClient
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
@@ -15,10 +16,14 @@ import scala.concurrent.duration._
  */
 trait RedoxTest {
 
-  val conf = ConfigFactory.load("resources/reference.conf")
-  val system = ActorSystem("redox-test")
-  val materializer = ActorMaterializer()(system)
-  val client = new RedoxClient(conf, system, materializer)
+  val conf = ClientConfig(ConfigFactory.load("resources/reference.conf"))
+  val httpClient = StandaloneAhcWSClient()
+  implicit val system = ActorSystem("redox-test")
+  implicit val materializer = ActorMaterializer()(system)
+
+
+  val tokenManager = new RedoxTokenManager(httpClient, conf.baseRestUri)
+  val client = new RedoxClient(conf, httpClient, tokenManager)
   val timeout: FiniteDuration = 20.seconds
 
   // Validate raw a raw JSON string, throwing a RuntimeException which will output detail to Specs2/Test console

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.1-SNAPSHOT"
+version in ThisBuild := "3.0.0-SNAPSHOT"


### PR DESCRIPTION
Adds the ability to handle multiple credentials for multiple sources.

Each source in redox has a unique set of api-key, api-secret credentials. If a client has multiple sources, this would have required creating multiple RedoxClients per each source.

However, redox-client constructed an internal WsClient (httpClient) and a akka schedule to manage the access-refresh Token lifecycle. This consumes unnecessary resources as each client would have created its own thread pool.

This PR:
- Abstracts away the token management to a seperate class `RedoxTokanManager` which handles storing and refreshing tokens.
- Redox client now only handle consuming of redox endpoints. The http client and token manager is injected in.
- HttpClient interface is added to unify play's internal `WSClient` and `StandaloneAhcWSClient` implementations.
- Redox client can accept a WsClient from outside (possibly play's injected client). A legacy constructer is still kept which creates an internal standalone HttpClient for easier migration.