### PR TITLE
[API-219] make demographics dob optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+- Breaking: Make Demographics.dob optional as it's not reliable in PatientUpdate
+messages.
+
 ## [4.0.0] - 2019-03-22
 
 ### Changed

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -52,7 +52,7 @@ object SexType extends Enumeration {
  *
  * @param FirstName Required
  * @param LastName Required
- * @param DOB Required. Patient's date of birth. In ISO 8601 format
+ * @param DOB Partially reliable. Patient's date of birth. In ISO 8601 format
  * @param Sex Required
  * @param Language Patient's primary spoken language. In ISO 639-1 alpha values (e.g. 'en'). http://www.mathguide.de/info/tools/languagecode.html
  * @param Citizenship Patient's nation(s) of citizenship. *In ISO 3166 alpha 2 format (e.g. 'US').
@@ -64,7 +64,7 @@ object SexType extends Enumeration {
 @jsonDefaults case class Demographics(
   FirstName: String,
   LastName: String,
-  DOB: DateTime,
+  DOB: Option[DateTime] = None,
   SSN: Option[String] = None,
   Sex: SexType.Value = SexType.Unknown,
   Address: Option[Address] = None,

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -18,7 +18,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
     "return an error" in {
       val shouldFailQuery = PatientQuery(
         Meta(DataModel = DataModelTypes.ClinicalSummary, EventType = RedoxEventTypes.Query),
-        Patient(Demographics = Some(Demographics("John", "Doe", DateTime.parse("1970-1-1"), Sex = SexType.Male)))
+        Patient(Demographics = Some(Demographics("John", "Doe", Some(DateTime.parse("1970-1-1")), Sex = SexType.Male)))
       )
       val fut = client.get[PatientQuery, ClinicalSummary](shouldFailQuery)
       val resp = Await.result(fut, timeout)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.1-SNAPSHOT"
+version in ThisBuild := "5.0.0-SNAPSHOT"


### PR DESCRIPTION
Related to [API-219]

Makes Demographics.dob optional as its not reliable in `PatientUpdate` messages.

[API-219]: https://vital-software.atlassian.net/browse/API-219