### PR TITLE
Fix codeset versus codesystem modelling in observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking**: Converted `CodeSet` into a trait, with implementations
-  `BasicCodeSet` and `CodeSetWithName`
+- **Breaking**: Renamed `CodeSet` to `Codeset` (note the lower-case `s`) to fix
+  mappings from JSON, converted it into a trait, with implementations
+  `BasicCodeset` and `CodesetWithName`
 - **Breaking**: Converted `Observation` into a trait, with implementations
   `ProcedureObservation`, `ResultObservation`, `VitalSignObservation` and
   `FlowsheetObservation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**: Converted `CodeSet` into a trait, with implementations
+  `BasicCodeSet` and `CodeSetWithName`
+- **Breaking**: Converted `Observation` into a trait, with implementations
+  `ProcedureObservation`, `ResultObservation`, `VitalSignObservation` and
+  `FlowsheetObservation`
+  - This was done to cope with the flowsheet observation not having a
+    `CodeSystem`
+
 ## [5.0.0] - 2019-03-25
 
 ### Changed

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
@@ -47,24 +47,24 @@ object CodeWithStatus extends RobustPrimitives
 
 
 // Alternative to 'Code' used inconsistently in some data models
-trait CodeSet {
+trait Codeset {
   def Code: Option[String]
-  def CodeSet: Option[String]
+  def Codeset: Option[String]
 }
 
-@jsonDefaults case class BasicCodeSet(
+@jsonDefaults case class BasicCodeset(
   Code: Option[String] = None,
-  CodeSet: Option[String] = None,
+  Codeset: Option[String] = None,
   Description: Option[String] = None,
-) extends CodeSet
+) extends Codeset
 
-object BasicCodeSet extends RobustPrimitives
+object BasicCodeset extends RobustPrimitives
 
-@jsonDefaults case class CodeSetWithName(
+@jsonDefaults case class CodesetWithName(
   Code: Option[String] = None,
-  CodeSet: Option[String] = None,
+  Codeset: Option[String] = None,
   Name: Option[String] = None,
   Type: Option[String] = None,
-) extends CodeSet
+) extends Codeset
 
-object CodeSetWithName extends RobustPrimitives
+object CodesetWithName extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
@@ -1,0 +1,70 @@
+package com.github.vitalsoftware.scalaredox.models
+
+import org.joda.time.DateTime
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
+
+/**
+ * Code reference (like a foreign key into a SNOMED, ICD-9/10, or other data set)
+ */
+trait Code {
+  def Code: Option[String]
+  def CodeSystem: Option[String]
+  def CodeSystemName: Option[String]
+  def Name: Option[String]
+}
+
+@jsonDefaults case class BasicCode(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None
+) extends Code
+
+object BasicCode extends RobustPrimitives
+
+@jsonDefaults case class CodeWithText(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  Text: Option[String] = None
+) extends Code
+
+object CodeWithText extends RobustPrimitives
+
+@jsonDefaults case class CodeWithStatus(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  Status: Option[String] = None,
+  DateTime: Option[DateTime] = None
+) extends Code
+
+object CodeWithStatus extends RobustPrimitives
+
+
+// Alternative to 'Code' used inconsistently in some data models
+trait CodeSet {
+  def Code: Option[String]
+  def CodeSet: Option[String]
+}
+
+@jsonDefaults case class BasicCodeSet(
+  Code: Option[String] = None,
+  CodeSet: Option[String] = None,
+  Description: Option[String] = None,
+) extends CodeSet
+
+object BasicCodeSet extends RobustPrimitives
+
+@jsonDefaults case class CodeSetWithName(
+  Code: Option[String] = None,
+  CodeSet: Option[String] = None,
+  Name: Option[String] = None,
+  Type: Option[String] = None,
+) extends CodeSet
+
+object CodeSetWithName extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -30,57 +30,6 @@ trait DateRange {
   def EndDate: Option[DateTime]
 }
 
-/**
- * Code reference (like a foreign key into a SNOMED, ICD-9/10, or other data set)
- */
-trait Code {
-  def Code: Option[String]
-  def CodeSystem: Option[String]
-  def CodeSystemName: Option[String]
-  def Name: Option[String]
-}
-
-@jsonDefaults case class BasicCode(
-  Code: Option[String] = None,
-  CodeSystem: Option[String] = None,
-  CodeSystemName: Option[String] = None,
-  Name: Option[String] = None
-) extends Code
-
-object BasicCode extends RobustPrimitives
-
-@jsonDefaults case class CodeWithText(
-  Code: Option[String] = None,
-  CodeSystem: Option[String] = None,
-  CodeSystemName: Option[String] = None,
-  Name: Option[String] = None,
-  Text: Option[String] = None
-) extends Code
-
-object CodeWithText extends RobustPrimitives
-
-@jsonDefaults case class CodeWithStatus(
-  Code: Option[String] = None,
-  CodeSystem: Option[String] = None,
-  CodeSystemName: Option[String] = None,
-  Name: Option[String] = None,
-  Status: Option[String] = None,
-  DateTime: Option[DateTime] = None
-) extends Code with Status
-
-object CodeWithStatus extends RobustPrimitives
-
-// Alternative to 'BasicCode' used inconsistently in some data models
-@jsonDefaults case class CodeSet(
-  Code: Option[String] = None,
-  Codeset: Option[String] = None,
-  Name: Option[String] = None,
-  Type: Option[String] = None,
-  Description: Option[String] = None
-)
-
-object CodeSet extends RobustPrimitives
-
 @jsonDefaults case class Address(
   StreetAddress: Option[String] = None,
   City: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -109,32 +109,6 @@ object ValueTypes extends Enumeration {
 }
 
 /**
- * Coded Observation of a patient.
- *
- * @param TargetSite Where (on or in the body) the observation is made. (e.g. "Entire hand (body structure)"). SNOMED CT
- * @param Interpretation A flag indicating whether or not the observed value is normal, high, or low. [Supported Values](https://www.hl7.org/fhir/v3/ObservationInterpretation/index.html)
- * @param ValueType Data type of the value. One of the following: "Numeric", "String", "Date", "Time", "DateTime", "Coded Entry", "Encapsulated Data". Derived from HL7 Table 0125.
- *                  @param Units The units of the measurement. [UCUM Units of Measure](http://unitsofmeasure.org/ucum.html)
- */
-@jsonDefaults case class Observation(
-  Code: Option[String] = None,
-  CodeSystem: Option[String] = None,
-  CodeSystemName: Option[String] = None,
-  Name: Option[String] = None,
-  DateTime: DateTime,
-  Status: Option[String] = None,
-  Value: Option[String] = None,
-  ValueType: Option[ValueTypes.Value] = None,
-  Units: Option[String] = None,
-  ReferenceRange: Option[ReferenceRange] = None,
-  TargetSite: Option[BasicCode] = None, // Used by Procedures
-  Interpretation: Option[String] = None, // Used by Result
-  Observer: Option[Provider] = None
-) extends Code with Status with DateStamped
-
-object Observation extends RobustPrimitives
-
-/**
  * This wraps java.util.Locale for consistent serialisation form language to an ISO standard language locale. The java
  * implementation doesn't guarantee the validation of the input and the json formats gets masked by play-json's
  * implementation that doesn't handle validation.

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/FlowSheetMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/FlowSheetMessage.scala
@@ -16,7 +16,7 @@ import com.github.vitalsoftware.util.RobustPrimitives
   Meta: Meta,
   Patient: Patient,
   Visit: Option[BasicVisitInfo] = None,
-  Observations: Seq[Observation] = Nil
+  Observations: Seq[FlowsheetObservation] = Nil
 ) extends MetaLike with HasPatient
 
 object FlowSheetMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Observation.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Observation.scala
@@ -90,14 +90,14 @@ object VitalSignObservation extends RobustPrimitives
   ValueType: Option[ValueTypes.Value] = None,
   Units: Option[String] = None,
   Code: Option[String] = None,
-  CodeSet: Option[String] = None,
+  Codeset: Option[String] = None,
   Description: Option[String] = None,
   Status: Option[String] = None,
   Notes: Seq[String] = Seq.empty,
   Observer: Option[Provider] = None,
   ReferenceRange: Option[ReferenceRange] = None,
   AbnormalFlag: Option[String] = None
-) extends Observation with CodeSet with ObservationValue
+) extends Observation with Codeset with ObservationValue
 
 object FlowsheetObservation extends RobustPrimitives
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Observation.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Observation.scala
@@ -1,0 +1,104 @@
+package com.github.vitalsoftware.scalaredox.models
+
+import org.joda.time.DateTime
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
+
+sealed trait Observation extends DateStamped with Status {
+  def Code: Option[String]
+}
+
+sealed trait ClinicalSummaryObservation extends Observation with Code
+
+sealed trait ObservationInterpretation { self: Observation =>
+  def Interpretation: Option[String]
+}
+
+sealed trait ObservationValue { self: Observation =>
+  def Value: Option[String]
+  def Units: Option[String]
+}
+
+/**
+ * Procedure observation
+ *
+ * Used within ClinicalSummary's Procedures.Observations[]. Has no units.
+ */
+@jsonDefaults case class ProcedureObservation(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  DateTime: DateTime,
+  Status: Option[String] = None,
+  TargetSite: Option[BasicCode] = None,
+) extends ClinicalSummaryObservation
+
+
+object ProcedureObservation extends RobustPrimitives
+
+/**
+ * Result observation
+ *
+ * Used within ClincialSummary's Results[].Observations[]
+ */
+@jsonDefaults case class ResultObservation(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  Status: Option[String] = None,
+  Interpretation: Option[String] = None, // Used by Result
+  DateTime: DateTime,
+  CodedValue: Option[BasicCode] = None, // Used by Result
+  Value: Option[String] = None,
+  ValueType: Option[ValueTypes.Value] = None,
+  Units: Option[String] = None,
+  ReferenceRange: Option[ReferenceRange] = None,
+) extends ClinicalSummaryObservation with ObservationInterpretation with ObservationValue
+
+object ResultObservation extends RobustPrimitives
+
+/**
+ * Vital sign observation
+ *
+ * Used within ClinicalSummary's VitalSigns[].Observations[]
+ */
+@jsonDefaults case class VitalSignObservation(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  Status: Option[String] = None,
+  Interpretation: Option[String] = None,
+  DateTime: DateTime,
+  Value: Option[String] = None,
+  Units: Option[String] = None,
+) extends ClinicalSummaryObservation with ObservationInterpretation with ObservationValue
+
+object VitalSignObservation extends RobustPrimitives
+
+/**
+ * Flowsheet observation
+ *
+ * Used within Flowsheet. Has a codeset instead of system. Has an observer.
+ */
+@jsonDefaults case class FlowsheetObservation(
+  DateTime: DateTime,
+  Value: Option[String] = None,
+  ValueType: Option[ValueTypes.Value] = None,
+  Units: Option[String] = None,
+  Code: Option[String] = None,
+  CodeSet: Option[String] = None,
+  Description: Option[String] = None,
+  Status: Option[String] = None,
+  Notes: Seq[String] = Seq.empty,
+  Observer: Option[Provider] = None,
+  ReferenceRange: Option[ReferenceRange] = None,
+  AbnormalFlag: Option[String] = None
+) extends Observation with CodeSet with ObservationValue
+
+object FlowsheetObservation extends RobustPrimitives
+
+

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -134,14 +134,14 @@ object OrderingFacility extends RobustPrimitives
   TransactionDateTime: Option[DateTime] = None,
   CollectionDateTime: Option[DateTime] = None,
   Specimen: Option[Specimen] = None,
-  Procedure: Option[CodeSet] = None,
+  Procedure: Option[BasicCodeSet] = None,
   Provider: Option[OrderProvider] = None,
   OrderingFacility: Option[OrderingFacility] = None,
   Priority: Option[OrderPriorityTypes.Value] = None,
   Expiration: Option[LocalDate] = None,
   Comments: Option[String] = None,
   Notes: Seq[String] = Seq.empty,
-  Diagnoses: Seq[CodeSet] = Seq.empty,
+  Diagnoses: Seq[CodeSetWithName] = Seq.empty,
   ClinicalInfo: Seq[ClinicalInfo] = Seq.empty
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Order.scala
@@ -53,7 +53,7 @@ object OrderPriorityTypes extends Enumeration {
  * List of supplementary clinical information associated with the order. Often these are answers to Ask at Order Entry (AOE) questions.
  *
  * @param Code Code for the information element
- * @param CodeSet Code set used to identify the information element. Codeset will be blank for system-defined codes. LOINC is used for a subset of AOE questions.
+ * @param Codeset Code set used to identify the information element. Codeset will be blank for system-defined codes. LOINC is used for a subset of AOE questions.
  * @param Description Description of the information element. For AOEs, this is typically the text of the AOE question
  * @param Value Value of the information element. For AOEs, this is typically the full answer
  * @param Units Units of the value. If the Value is a time range, this may be "WK"
@@ -62,13 +62,13 @@ object OrderPriorityTypes extends Enumeration {
  */
 @jsonDefaults case class ClinicalInfo(
   Code: Option[String] = None,
-  CodeSet: Option[String] = None,
+  Codeset: Option[String] = None,
   Description: Option[String] = None,
   Value: Option[String] = None,
   Units: Option[String] = None,
   Abbreviation: Option[String] = None,
   Notes: Seq[String] = Seq.empty
-)
+) extends Codeset
 
 object ClinicalInfo extends RobustPrimitives
 
@@ -134,14 +134,14 @@ object OrderingFacility extends RobustPrimitives
   TransactionDateTime: Option[DateTime] = None,
   CollectionDateTime: Option[DateTime] = None,
   Specimen: Option[Specimen] = None,
-  Procedure: Option[BasicCodeSet] = None,
+  Procedure: Option[BasicCodeset] = None,
   Provider: Option[OrderProvider] = None,
   OrderingFacility: Option[OrderingFacility] = None,
   Priority: Option[OrderPriorityTypes.Value] = None,
   Expiration: Option[LocalDate] = None,
   Comments: Option[String] = None,
   Notes: Seq[String] = Seq.empty,
-  Diagnoses: Seq[CodeSetWithName] = Seq.empty,
+  Diagnoses: Seq[CodesetWithName] = Seq.empty,
   ClinicalInfo: Seq[ClinicalInfo] = Seq.empty
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -106,7 +106,7 @@ object Contact extends RobustPrimitives
   Contacts: Seq[Contact] = Seq.empty,
   Guarantor: Option[Guarantor] = None,
   Insurances: Seq[Insurance] = Seq.empty,
-  Diagnoses: Seq[CodeSetWithName] = Seq.empty,
+  Diagnoses: Seq[CodesetWithName] = Seq.empty,
   PCP: Option[Provider] = None
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -106,7 +106,7 @@ object Contact extends RobustPrimitives
   Contacts: Seq[Contact] = Seq.empty,
   Guarantor: Option[Guarantor] = None,
   Insurances: Seq[Insurance] = Seq.empty,
-  Diagnoses: Seq[BasicCode] = Seq.empty,
+  Diagnoses: Seq[CodeSetWithName] = Seq.empty,
   PCP: Option[Provider] = None
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Procedures.scala
@@ -14,7 +14,7 @@ import com.github.vitalsoftware.util.RobustPrimitives
  * @param Services These are procedures that are service-oriented in nature, such as a dressing change, or feeding a patient.
  */
 @jsonDefaults case class Procedures(
-  Observations: Seq[Observation] = Seq.empty,
+  Observations: Seq[ProcedureObservation] = Seq.empty,
   Procedures: Seq[CodeWithStatus] = Seq.empty,
   Services: Seq[CodeWithStatus] = Seq.empty
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.{ Format, Reads, Writes }
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Status: Option[String] = None,
-  Observations: Seq[Observation] = Seq.empty
+  Observations: Seq[ResultObservation] = Seq.empty
 ) extends Code with Status
 
 object ChartResult extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -82,7 +82,7 @@ object ResultPerformer extends RobustPrimitives
   Producer: Option[OrderProducer] = None,
   Performer: Option[ResultPerformer] = None,
   ReferenceRange: Option[ReferenceRange] = None,
-  ObservationMethod: Option[BasicCodeSet] = None
+  ObservationMethod: Option[BasicCodeset] = None
 )
 
 object Result extends RobustPrimitives
@@ -121,7 +121,7 @@ object ResultsStatusTypes extends Enumeration {
   CompletionDateTime: Option[DateTime] = None,
   Notes: Seq[String] = Seq.empty,
   ResultsStatus: Option[ResultsStatusTypes.Value] = None,
-  Procedure: Option[BasicCodeSet] = None,
+  Procedure: Option[BasicCodeset] = None,
   Provider: Option[Provider] = None,
   Status: String,
   ResponseFlag: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Result.scala
@@ -82,7 +82,7 @@ object ResultPerformer extends RobustPrimitives
   Producer: Option[OrderProducer] = None,
   Performer: Option[ResultPerformer] = None,
   ReferenceRange: Option[ReferenceRange] = None,
-  ObservationMethod: Option[CodeSet] = None
+  ObservationMethod: Option[BasicCodeSet] = None
 )
 
 object Result extends RobustPrimitives
@@ -121,7 +121,7 @@ object ResultsStatusTypes extends Enumeration {
   CompletionDateTime: Option[DateTime] = None,
   Notes: Seq[String] = Seq.empty,
   ResultsStatus: Option[ResultsStatusTypes.Value] = None,
-  Procedure: Option[CodeSet] = None,
+  Procedure: Option[BasicCodeSet] = None,
   Provider: Option[Provider] = None,
   Status: String,
   ResponseFlag: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -54,7 +54,7 @@ object VisitQuery extends RobustPrimitives
   Value: String,
   DateTime: DateTime,
   IsNegativeIndicator: Option[Boolean],
-  Encodings: Seq[BasicCodeSet] = Seq.empty
+  Encodings: Seq[BasicCodeset] = Seq.empty
 )
 
 object Diagnosis extends RobustPrimitives
@@ -105,7 +105,7 @@ object PatientClassType extends Enumeration {
   Type: Option[String] = None, // Claims[].Visit
   DateTime: Option[DateTime] = None,
   DischargeDateTime: Option[DateTime] = None,
-  DischargeStatus: Option[BasicCodeSet] = None,
+  DischargeStatus: Option[BasicCodeset] = None,
   DischargeLocation: Option[CareLocation] = None,
 
   StartDateTime: Option[DateTime] = None, // Header.Document.Visit only

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -4,7 +4,7 @@ import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.macros._
 import com.github.vitalsoftware.util.RobustPrimitives
-import play.api.libs.json.{ Format, Reads, Writes }
+import play.api.libs.json._
 
 /**
  * Created by apatzer on 3/17/17.
@@ -54,7 +54,7 @@ object VisitQuery extends RobustPrimitives
   Value: String,
   DateTime: DateTime,
   IsNegativeIndicator: Option[Boolean],
-  Encodings: Seq[CodeSet] = Seq.empty
+  Encodings: Seq[BasicCodeSet] = Seq.empty
 )
 
 object Diagnosis extends RobustPrimitives
@@ -105,7 +105,7 @@ object PatientClassType extends Enumeration {
   Type: Option[String] = None, // Claims[].Visit
   DateTime: Option[DateTime] = None,
   DischargeDateTime: Option[DateTime] = None,
-  DischargeStatus: Option[CodeSet] = None,
+  DischargeStatus: Option[BasicCodeSet] = None,
   DischargeLocation: Option[CareLocation] = None,
 
   StartDateTime: Option[DateTime] = None, // Header.Document.Visit only

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VitalSigns.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VitalSigns.scala
@@ -16,7 +16,7 @@ import play.api.libs.json.{ Format, Reads, Writes }
  */
 @jsonDefaults case class VitalSigns(
   DateTime: DateTime,
-  Observations: Seq[Observation] = Seq.empty
+  Observations: Seq[VitalSignObservation] = Seq.empty
 )
 
 object VitalSigns extends RobustPrimitives

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.1-SNAPSHOT"
+version in ThisBuild := "6.0.0-SNAPSHOT"


### PR DESCRIPTION
- Renames `CodeSet` to `Codeset` to match Redox (so the value actually comes through from the JSON), and splits it into similar subtypes as `Code` (`..WithName` for things with a name as well as a Codeset, etc.)
- Splits `Observation` into four different subclasses, because the four places we currently use that class all have different properties (and, chiefly, the observations on a flowsheet have Codeset not CodeSystem)

Will change base of PR to master when #86 is merged.