### PR TITLE
[API-239] Fix medications message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- MedicationsMessage had some incorrect properties:
+  - MedicationsMessage.Order.Indications are now a sequence instead of an Option
+  - MedicationsMessage.Visit now use VisitInfo instead of Visit
+
 ## [6.0.1] - 2019-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MedicationsMessage had some incorrect properties:
   - MedicationsMessage.Order.Indications are now a sequence instead of an Option
-  - MedicationsMessage.Visit now use VisitInfo instead of Visit
+  - MedicationsMessage.Visit now use Option[VisitInfo] instead of Visit
+- MedicationsMessage now extend MetaLike, HasPatient and HasVisitInfo
+(which are required for message models)
 
 ## [6.0.1] - 2019-04-11
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
@@ -139,8 +139,8 @@ object MedicationOrder extends RobustPrimitives
 @jsonDefaults case class MedicationsMessage(
   Meta: Meta,
   Patient: Patient,
-  Visit: VisitInfo,
+  Visit: Option[VisitInfo] = None,
   Order: MedicationOrder,
-)
+) extends MetaLike with HasPatient with HasVisitInfo
 
 object MedicationsMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
@@ -121,7 +121,7 @@ object OrderedMedication extends RobustPrimitives
   ID: String,
   Notes: Seq[String] = Seq.empty,
   Medication: OrderedMedication,
-  Indications: Option[BasicCode],
+  Indications: Seq[BasicCode] = Seq.empty,
   Provider: Option[OrderProvider] = None,
   EnteredBy: Option[Provider] = None,
   VerifiedBy: Option[Provider] = None,
@@ -139,7 +139,7 @@ object MedicationOrder extends RobustPrimitives
 @jsonDefaults case class MedicationsMessage(
   Meta: Meta,
   Patient: Patient,
-  Visit: Visit,
+  Visit: VisitInfo,
   Order: MedicationOrder,
 )
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -21,7 +21,7 @@ object DataModelTypes extends Enumeration {
 
 object RedoxEventTypes extends Enumeration {
   val QueryResponse = Value("Query Response")
-  val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge, GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery, PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace, Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse, VisitPush, VisitUpdate,  Administration  = Value
+  val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge, GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery, PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace, Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse, VisitPush, VisitUpdate, Administration = Value
 
   @transient implicit lazy val jsonFormat: Format[RedoxEventTypes.Value] = Format(Reads.enumNameReads(RedoxEventTypes), Writes.enumNameWrites)
 }


### PR DESCRIPTION
Related to [API-239]

MedicationsMessage had some incorrect properties:
  - MedicationsMessage.Order.Indications are now a sequence instead of an Option
  - MedicationsMessage.Visit now use VisitInfo instead of Visit


[API-239]: https://vital-software.atlassian.net/browse/API-239