### PR TITLE
[API-198] Handle other locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Redox sometimes send Language value as "Other" for non-ISO standard values.
+These "Other" values will get assigned the java.util.Locale.ROOT when deserialized.
+
+
 ## [6.0.3] - 2019-04-15
 
 ### Changed

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -124,6 +124,7 @@ object Language {
 
   val jsonReads: Reads[Language] = new Reads[Language] {
     override def reads(json: JsValue): JsResult[Language] = json match {
+      case JsString("Other") => JsSuccess(Language(Locale.ROOT))
       case JsString(str) if Try(new Locale(str).getISO3Language).isSuccess => JsSuccess(Language(Locale.forLanguageTag(str)))
       case _ => JsError(Seq(JsPath -> Seq(JsonValidationError("error.expected.locale"))))
     }

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/models/CommonTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/models/CommonTest.scala
@@ -20,6 +20,10 @@ class CommonTest extends Specification {
       JsString("fr").validate[Language] must beLanguageOf("fra")
     }
 
+    "read 'Other' language locale" in {
+      JsString("Other").validate[Language] must beLanguageOf("")
+    }
+
     "read invalid language locale" in {
       val unknown = JsString("unknown").validate[Language]
       unknown must beAnInstanceOf[JsError]


### PR DESCRIPTION
Resolves [API-198]

Redox sometimes send Language value as "Other" for non-ISO standard values.
These "Other" values will get assigned the java.util.Locale.ROOT when deserialized.

> The root locale is the locale whose language, country, and variant are empty ("") strings.  This is regarded as the base locale of all locales, and is used as the language/country neutral locale for the locale sensitive operations.


[API-198]: https://vital-software.atlassian.net/browse/API-198