### PR TITLE
Upgrade akka-http to 10.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking** Upgrade to akka-http 10.1.8
+
 ## [7.0.0] - 2019-08-22
 
 ### Changed

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json-joda" % playJsonVersion,
   "com.typesafe.play" %% "play-ahc-ws" % playVersion,
   "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.2",
-  "com.typesafe.akka" %% "akka-http" % "10.0.14",
+  "com.typesafe.akka" %% "akka-http" % "10.1.8",
 
   "com.github.vital-software" %% "json-annotation" % "0.6.0",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "7.0.1-SNAPSHOT"
+version in ThisBuild := "8.0.0-SNAPSHOT"


### PR DESCRIPTION
## Purpose
Upgrade to akka-http 10.1.8

10.0.14 was causing some incompatibility issues with some libraries when they tried to use this with play 2.7