### PR TITLE
Add `Invalid` sentinel types to Meta's DataModel and EventType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `Invalid` sentinel values to `DataModel` and `EventType` enums, so that
+  it is possible to construct a `Meta` for any JSON message (essentially, all
+  fields on `Meta` are now optional)
+
 ## [8.0.0] - 2019-08-26
 
 ### Changed

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -14,14 +14,14 @@ import play.api.libs.json.{ Format, Reads, Writes }
 
 object DataModelTypes extends Enumeration {
   val ClinicalSummary = Value("Clinical Summary")
-  val Claim, Device, Financial, Flowsheet, Inventory, Media, Notes, Order, PatientAdmin, PatientSearch, Referral, Results, Scheduling, SurgicalScheduling, Vaccination, Medications = Value
+  val Claim, Device, Financial, Flowsheet, Inventory, Media, Notes, Order, PatientAdmin, PatientSearch, Referral, Results, Scheduling, SurgicalScheduling, Vaccination, Medications, Invalid = Value
 
   @transient implicit lazy val jsonFormat: Format[DataModelTypes.Value] = Format(Reads.enumNameReads(DataModelTypes), Writes.enumNameWrites)
 }
 
 object RedoxEventTypes extends Enumeration {
   val QueryResponse = Value("Query Response")
-  val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge, GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery, PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace, Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse, VisitPush, VisitUpdate, Administration = Value
+  val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge, GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery, PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace, Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse, VisitPush, VisitUpdate, Administration, Invalid = Value
 
   @transient implicit lazy val jsonFormat: Format[RedoxEventTypes.Value] = Format(Reads.enumNameReads(RedoxEventTypes), Writes.enumNameWrites)
 }


### PR DESCRIPTION
It's useful to be able to represent the Meta for a message that failed to be processed by the current version of scala-redox. This is already almost possible, because almost all the fields of `Meta` are optional.

The exceptions are the `DataModel` and `EventType` fields, which contain an `Enumeration`. A failed Redox message may contain an invalid (or new/unseen) value for one of those fields, which would prevent us instantiating a `Meta` for the message.

Essentially, this is the same as if we changed the `DataModel` and `EventType` fields on `Meta` into e.g. `Option[DataModel.Value]`. But without the BC break.