### PR TITLE
bump version to 8.0.3

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.0.2-SNAPSHOT"
+version in ThisBuild := "8.0.3-SNAPSHOT"


### PR DESCRIPTION
## Purpose
The previous release failed to push the new version to master.

https://buildkite.com/vital/scala-redox/builds/250#9d855529-8fee-48b5-910e-7e5cf678ef73

The underlying issue of vital-bot access has been fixed. This just increases the version.